### PR TITLE
Fix line jump gaps on bottom-to-top vertical segments (edges 72/73)

### DIFF
--- a/src/pathfinding.ts
+++ b/src/pathfinding.ts
@@ -733,8 +733,15 @@ export function waypointsToSvgPathWithHops(
           for (const cy of filtered) {
             // The arc peaks at cy - ARC_R (top of the semicircle) — center the gap there
             const gapCenter = cy - ARC_R;
-            parts.push(`L ${x} ${gapCenter - GAP_HALF}`);
-            parts.push(`M ${x} ${gapCenter + GAP_HALF}`);
+            if (topToBottom) {
+              // Traveling downward (increasing Y): stop above gap, jump past it
+              parts.push(`L ${x} ${gapCenter - GAP_HALF}`);
+              parts.push(`M ${x} ${gapCenter + GAP_HALF}`);
+            } else {
+              // Traveling upward (decreasing Y): stop below gap, jump past it
+              parts.push(`L ${x} ${gapCenter + GAP_HALF}`);
+              parts.push(`M ${x} ${gapCenter - GAP_HALF}`);
+            }
           }
           parts.push(`L ${segEndX} ${segEndY}`);
         } else {
@@ -830,8 +837,13 @@ function buildVerticalSegmentWithGaps(
   for (const cy of filtered) {
     // The arc peaks at cy - ARC_R (top of the semicircle) — center the gap there
     const gapCenter = cy - ARC_R;
-    parts.push(`L ${x} ${gapCenter - GAP_HALF}`);
-    parts.push(`M ${x} ${gapCenter + GAP_HALF}`);
+    if (topToBottom) {
+      parts.push(`L ${x} ${gapCenter - GAP_HALF}`);
+      parts.push(`M ${x} ${gapCenter + GAP_HALF}`);
+    } else {
+      parts.push(`L ${x} ${gapCenter + GAP_HALF}`);
+      parts.push(`M ${x} ${gapCenter - GAP_HALF}`);
+    }
   }
   parts.push(`L ${x} ${y2}`);
   return parts.join(" ");


### PR DESCRIPTION
The gap (moveTo cut) on vertical segments was hardcoded assuming top-to-bottom travel direction. For bottom-to-top segments (like edge-73 going from Mac Studio up to Ethernet Switch), the L command drew through the gap and the M jumped back into it, producing no visible gap. Now the gap boundaries are swapped based on travel direction so the line stops at the near edge and jumps to the far edge.

https://claude.ai/code/session_01Nb6BvVU82in1Ya9MWTbCKy

## Description

<!-- What does this PR do? -->

## Testing

<!-- How did you verify the changes work? -->

## Screenshots

<!-- If this is a UI change, include before/after screenshots. -->
