### PR TITLE
Fix cable labels rendering behind edges with elevated zIndex

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -84,6 +84,11 @@ html, body, #root {
   pointer-events: none;
 }
 
+/* Edge labels must sit above edges with elevated zIndex (line-jump hops) */
+.react-flow__edgelabel-renderer {
+  z-index: 2;
+}
+
 .react-flow__edge-path {
   stroke-width: 2;
 }


### PR DESCRIPTION
React Flow's .react-flow__edgelabel-renderer has no explicit z-index, so edges with zIndex: 1 (hop edges for line jumps) paint on top of the label portal container. Give the label renderer z-index: 2 so labels always appear above edge paths.

https://claude.ai/code/session_01Nb6BvVU82in1Ya9MWTbCKy

## Description

<!-- What does this PR do? -->

## Testing

<!-- How did you verify the changes work? -->

## Screenshots

<!-- If this is a UI change, include before/after screenshots. -->
