### PR TITLE
Increase maximum cache file size to 3MB

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       workbox: {
+        maximumFileSizeToCacheInBytes: 3145728,
         globPatterns: ['**/*.{js,css,html,svg,png,ttf,json}'],
         globIgnores: [
           '**/deviceLibrary.fallback.json',


### PR DESCRIPTION

## Description
App-BUJMPWON.js was 2.1MB and exceeds the default 2MB limit. Increased limit to 3MB

This was causing issues standing up a docker instance for testing other feature branches.
