### PR TITLE
Feature Addition - Nested subrooms with equipment rack toggle

### DIFF
--- a/docs/src/pages/RoomsAndGrouping.tsx
+++ b/docs/src/pages/RoomsAndGrouping.tsx
@@ -30,6 +30,26 @@ export default function RoomsAndGroupingPage() {
         <li>The device stays visually inside the room's dashed border</li>
       </ul>
 
+      <h2>Subrooms</h2>
+      <p>
+        Rooms can be nested inside other rooms to represent <strong>equipment locations within a physical space</strong> —
+        for example, a rack bay or stage box inside a larger studio room.
+      </p>
+      <ul>
+        <li><strong>Drag a room onto another room</strong> — the inner room becomes a subroom of the outer room</li>
+        <li><strong>Drag a subroom out</strong> — it detaches and becomes a top-level room again</li>
+        <li>Nesting is <strong>arbitrary depth</strong> — subrooms can contain their own subrooms</li>
+        <li>A room <strong>cannot be dropped into one of its own descendants</strong> (circular nesting is blocked)</li>
+      </ul>
+      <p>
+        Subrooms are visually distinct from top-level rooms: they default to a <strong>solid border</strong> and
+        a slightly more opaque background. This can still be customized via Room Properties.
+      </p>
+      <p>
+        When a parent room is deleted, its subrooms and devices are <strong>un-parented</strong> rather than deleted,
+        preserving their content at the correct absolute position on the canvas.
+      </p>
+
       <h2>Resizing rooms</h2>
       <p>
         Select a room to see resize handles on its corners and edges. Drag them to make the room larger or smaller.
@@ -73,8 +93,10 @@ export default function RoomsAndGroupingPage() {
 
       <h2>Deleting rooms</h2>
       <p>
-        When you delete a room, its child devices are <strong>un-parented</strong> (converted to absolute positions)
-        rather than deleted. This prevents accidentally losing device configurations.
+        When you delete a room, its children (devices and subrooms) are <strong>un-parented</strong> (converted to
+        absolute positions) rather than deleted. This prevents accidentally losing device configurations.
+        Use <strong>Delete Room &amp; Contents</strong> from the context menu to remove a room and everything inside
+        it — including nested subrooms at any depth.
       </p>
     </>
   );

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "easyschematic",
   "private": true,
   "license": "AGPL-3.0",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "type": "module",
   "description": "Browser-based AV signal flow diagram tool for designing audio/video system schematics",
   "homepage": "https://easyschematic.live",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -963,16 +963,16 @@ function SchematicCanvas() {
         useSchematicStore.setState({ isDragging: false, overlapNodeId: null });
       }
 
-      if (draggedNode.type === "room") return;
-      // Compute absolute position for reparenting check
+      // Compute absolute position by walking the full parent chain
       let absX = finalX;
       let absY = finalY;
-      if (draggedNode.parentId) {
-        const parent = state.nodes.find((n) => n.id === draggedNode.parentId);
-        if (parent) {
-          absX += parent.position.x;
-          absY += parent.position.y;
-        }
+      let parentId: string | undefined = draggedNode.parentId as string | undefined;
+      while (parentId) {
+        const parent = state.nodes.find((n) => n.id === parentId);
+        if (!parent) break;
+        absX += parent.position.x;
+        absY += parent.position.y;
+        parentId = parent.parentId as string | undefined;
       }
       reparentNode(draggedNode.id, { x: absX, y: absY });
     },

--- a/src/components/RoomContextMenu.tsx
+++ b/src/components/RoomContextMenu.tsx
@@ -37,6 +37,12 @@ export default function RoomContextMenu() {
     useSchematicStore.setState({ roomContextMenu: null });
   }, [menu]);
 
+  const toggleEquipmentRack = useCallback(() => {
+    if (!menu) return;
+    useSchematicStore.getState().toggleEquipmentRack(menu.nodeId);
+    useSchematicStore.setState({ roomContextMenu: null });
+  }, [menu]);
+
   const deleteRoom = useCallback(() => {
     if (!menu) return;
     useSchematicStore.setState({ roomContextMenu: null });
@@ -52,7 +58,10 @@ export default function RoomContextMenu() {
   if (!menu) return null;
 
   const node = useSchematicStore.getState().nodes.find((n) => n.id === menu.nodeId);
-  const isLocked = !!(node?.data as RoomData | undefined)?.locked;
+  const roomData = node?.data as RoomData | undefined;
+  const isLocked = !!roomData?.locked;
+  const isNested = !!node?.parentId;
+  const isEquipmentRack = !!roomData?.isEquipmentRack;
 
   return (
     <div
@@ -62,6 +71,12 @@ export default function RoomContextMenu() {
     >
       <MenuItem label="Edit Properties..." onClick={editProperties} />
       <MenuItem label={isLocked ? "Unlock Room" : "Lock Room"} onClick={toggleLock} />
+      {isNested && (
+        <MenuItem
+          label={isEquipmentRack ? "Remove Equipment Rack" : "Mark as Equipment Rack"}
+          onClick={toggleEquipmentRack}
+        />
+      )}
       <div className="border-t border-gray-200 my-1" />
       <MenuItem label="Delete Room" onClick={deleteRoom} danger />
       <MenuItem label="Delete Room & Contents" onClick={deleteRoomAndContents} danger />

--- a/src/components/RoomEditor.tsx
+++ b/src/components/RoomEditor.tsx
@@ -59,7 +59,7 @@ export default function RoomEditor() {
     };
     updateRoom(editingNodeId, data);
     close();
-  }, [editingNodeId, label, color, borderColor, borderStyle, labelSize, updateRoom, close]);
+  }, [editingNodeId, label, color, borderColor, borderStyle, labelSize, isEquipmentRack, updateRoom, close]);
 
   if (!editingNodeId || !node) return null;
 

--- a/src/components/RoomEditor.tsx
+++ b/src/components/RoomEditor.tsx
@@ -30,6 +30,7 @@ export default function RoomEditor() {
   const [borderStyle, setBorderStyle] = useState<RoomData["borderStyle"]>("dashed");
   const [labelSize, setLabelSize] = useState(12);
   const [locked, setLocked] = useState(false);
+  const [isEquipmentRack, setIsEquipmentRack] = useState(false);
 
   /* eslint-disable react-hooks/set-state-in-effect -- syncing props to local editor state */
   useEffect(() => {
@@ -40,6 +41,7 @@ export default function RoomEditor() {
     setBorderStyle(node.data.borderStyle ?? "dashed");
     setLabelSize(node.data.labelSize ?? 12);
     setLocked(node.data.locked ?? false);
+    setIsEquipmentRack(node.data.isEquipmentRack ?? false);
   }, [node]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
@@ -53,6 +55,7 @@ export default function RoomEditor() {
       ...(borderColor ? { borderColor } : {}),
       ...(borderStyle && borderStyle !== "dashed" ? { borderStyle } : {}),
       ...(labelSize !== 12 ? { labelSize } : {}),
+      ...(isEquipmentRack ? { isEquipmentRack: true } : {}),
     };
     updateRoom(editingNodeId, data);
     close();
@@ -114,6 +117,25 @@ export default function RoomEditor() {
               {locked ? "Locked" : "Unlocked"}
             </button>
           </div>
+
+          {/* Equipment Rack — only for nested rooms */}
+          {node.parentId && (
+            <div>
+              <label className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-1">
+                Equipment Rack
+              </label>
+              <button
+                onClick={() => setIsEquipmentRack(!isEquipmentRack)}
+                className={`px-3 py-1 text-xs rounded border cursor-pointer transition-colors ${
+                  isEquipmentRack
+                    ? "bg-blue-50 border-blue-400 text-blue-700"
+                    : "bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text)] hover:text-[var(--color-text-heading)]"
+                }`}
+              >
+                {isEquipmentRack ? "Yes" : "No"}
+              </button>
+            </div>
+          )}
 
           {/* Label Size */}
           <div>

--- a/src/components/RoomNode.tsx
+++ b/src/components/RoomNode.tsx
@@ -4,6 +4,19 @@ import type { RoomNode as RoomNodeType, SchematicNode } from "../types";
 import { useSchematicStore } from "../store";
 import { computeResizeSnap } from "../snapUtils";
 
+function RackIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="2" y="2" width="20" height="5" rx="1" />
+      <rect x="2" y="9" width="20" height="5" rx="1" />
+      <rect x="2" y="16" width="20" height="5" rx="1" />
+      <line x1="6" y1="4.5" x2="6" y2="4.5" strokeWidth="3" />
+      <line x1="6" y1="11.5" x2="6" y2="11.5" strokeWidth="3" />
+      <line x1="6" y1="18.5" x2="6" y2="18.5" strokeWidth="3" />
+    </svg>
+  );
+}
+
 function LockIcon() {
   return (
     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -62,7 +75,8 @@ function RoomNodeComponent({ id, data, selected }: NodeProps<RoomNodeType>) {
     setEditing(false);
   };
 
-  const borderStyleVal = data.borderStyle ?? (isSubroom ? "solid" : "dashed");
+  const isRack = data.isEquipmentRack ?? false;
+  const borderStyleVal = isRack ? "solid" : (data.borderStyle ?? (isSubroom ? "solid" : "dashed"));
   const borderColorVal = selected ? undefined : data.borderColor;
   const bgColor = data.color;
   // Subrooms use a slightly more opaque background so they read as distinct zones
@@ -87,8 +101,14 @@ function RoomNodeComponent({ id, data, selected }: NodeProps<RoomNodeType>) {
         style={{
           pointerEvents: "none",
           borderStyle: borderStyleVal,
-          ...(!selected ? { borderColor: borderColorVal || "var(--color-border)" } : {}),
-          backgroundColor: bgColor ? `${bgColor}${bgAlpha}` : selected ? "rgba(239,246,255,0.3)" : "rgba(var(--color-surface-rgb, 245,245,245),0.3)",
+          ...(!selected ? { borderColor: borderColorVal || (isRack ? "#6b7280" : "var(--color-border)") } : {}),
+          backgroundColor: bgColor
+            ? `${bgColor}${bgAlpha}`
+            : isRack
+            ? "rgba(55,65,81,0.12)"
+            : selected
+            ? "rgba(239,246,255,0.3)"
+            : "rgba(var(--color-surface-rgb, 245,245,245),0.3)",
         }}
       >
         <div
@@ -120,10 +140,11 @@ function RoomNodeComponent({ id, data, selected }: NodeProps<RoomNodeType>) {
             />
           ) : (
             <span
-              className="font-semibold uppercase tracking-wide cursor-text select-none"
-              style={{ fontSize, color: borderColorVal || "var(--color-text-muted)" }}
+              className="font-semibold uppercase tracking-wide cursor-text select-none flex items-center gap-1"
+              style={{ fontSize, color: borderColorVal || (isRack ? "#374151" : "var(--color-text-muted)") }}
               onDoubleClick={() => { setValue(data.label); setEditing(true); }}
             >
+              {isRack && <RackIcon />}
               {data.label}
             </span>
           )}

--- a/src/components/RoomNode.tsx
+++ b/src/components/RoomNode.tsx
@@ -26,6 +26,7 @@ function RoomNodeComponent({ id, data, selected }: NodeProps<RoomNodeType>) {
   const updateRoomLabel = useSchematicStore((s) => s.updateRoomLabel);
   const toggleRoomLock = useSchematicStore((s) => s.toggleRoomLock);
   const setResizeGuides = useSchematicStore((s) => s.setResizeGuides);
+  const isSubroom = useSchematicStore((s) => !!s.nodes.find((n) => n.id === id)?.parentId);
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(data.label);
 
@@ -61,9 +62,11 @@ function RoomNodeComponent({ id, data, selected }: NodeProps<RoomNodeType>) {
     setEditing(false);
   };
 
-  const borderStyleVal = data.borderStyle ?? "dashed";
+  const borderStyleVal = data.borderStyle ?? (isSubroom ? "solid" : "dashed");
   const borderColorVal = selected ? undefined : data.borderColor;
   const bgColor = data.color;
+  // Subrooms use a slightly more opaque background so they read as distinct zones
+  const bgAlpha = isSubroom ? "33" : "1a"; // 20% vs 10% opacity
   const fontSize = data.labelSize ?? 12;
 
   return (
@@ -85,7 +88,7 @@ function RoomNodeComponent({ id, data, selected }: NodeProps<RoomNodeType>) {
           pointerEvents: "none",
           borderStyle: borderStyleVal,
           ...(!selected ? { borderColor: borderColorVal || "var(--color-border)" } : {}),
-          backgroundColor: bgColor ? `${bgColor}1a` : selected ? "rgba(239,246,255,0.3)" : "rgba(var(--color-surface-rgb, 245,245,245),0.3)",
+          backgroundColor: bgColor ? `${bgColor}${bgAlpha}` : selected ? "rgba(239,246,255,0.3)" : "rgba(var(--color-surface-rgb, 245,245,245),0.3)",
         }}
       >
         <div

--- a/src/csvImport.ts
+++ b/src/csvImport.ts
@@ -721,6 +721,24 @@ export function buildImportResult(
     }
   }
 
+  // Re-stack top-level rooms vertically. ROOM_GAP (80px) between layout bands
+  // is far smaller than the parent-room padding on both sides (60px × 2 = 120px
+  // per room), so parent rooms still overlap after sizing. Sort by current y
+  // and stack them cleanly — subrooms stay correct since their positions are
+  // already relative to their parent at this point.
+  const topLevelRooms = nodes
+    .filter((n) => n.type === "room" && !n.parentId)
+    .sort((a, b) => a.position.y - b.position.y);
+
+  if (topLevelRooms.length > 1) {
+    const OUTER_GAP = 40;
+    let curY = topLevelRooms[0].position.y;
+    for (const room of topLevelRooms) {
+      room.position = { ...room.position, y: curY };
+      curY += ((room.style as Record<string, number>).height ?? 300) + OUTER_GAP;
+    }
+  }
+
   // Create edges
   const usedPorts = new Map<string, Set<string>>(); // nodeId → set of used port IDs
   let edgeCounter = importCounter;

--- a/src/csvImport.ts
+++ b/src/csvImport.ts
@@ -730,11 +730,18 @@ export function buildImportResult(
     .filter((n) => n.type === "room" && !n.parentId)
     .sort((a, b) => a.position.y - b.position.y);
 
-  if (topLevelRooms.length > 1) {
+  if (topLevelRooms.length > 0) {
     const OUTER_GAP = 40;
-    let curY = topLevelRooms[0].position.y;
+    const CANVAS_ORIGIN = 40; // minimum x/y offset from canvas edge
+
+    // Normalize x: shift all top-level rooms so the leftmost starts at CANVAS_ORIGIN
+    const minX = Math.min(...topLevelRooms.map((r) => r.position.x));
+    const xShift = CANVAS_ORIGIN - minX;
+
+    // Stack vertically starting at CANVAS_ORIGIN, applying x normalization
+    let curY = CANVAS_ORIGIN;
     for (const room of topLevelRooms) {
-      room.position = { ...room.position, y: curY };
+      room.position = { x: room.position.x + xShift, y: curY };
       curY += ((room.style as Record<string, number>).height ?? 300) + OUTER_GAP;
     }
   }

--- a/src/csvImport.ts
+++ b/src/csvImport.ts
@@ -444,8 +444,18 @@ function autoLayout(
   // Sort within each layer alphabetically for determinism
   for (const group of layerGroups.values()) group.sort();
 
-  // Collect unique rooms (preserving order)
-  const roomNames = [...new Set(deviceRooms.values())];
+  // Collect unique rooms, sorted so all paths under the same top-level room are
+  // consecutive. Without this, CSV row order can interleave bands from different
+  // parent rooms, causing parent room nodes to span across unrelated siblings.
+  const roomNames = [...new Set(deviceRooms.values())].sort((a, b) => {
+    const aParts = a.split(">").map((s) => s.trim());
+    const bParts = b.split(">").map((s) => s.trim());
+    for (let i = 0; i < Math.min(aParts.length, bParts.length); i++) {
+      const cmp = aParts[i].localeCompare(bParts[i]);
+      if (cmp !== 0) return cmp;
+    }
+    return aParts.length - bParts.length;
+  });
   const hasRooms = roomNames.length > 0;
 
   // Position devices with size-aware spacing

--- a/src/csvImport.ts
+++ b/src/csvImport.ts
@@ -537,31 +537,61 @@ export function buildImportResult(
   }
 
   // Build room assignments
-  const deviceRoom = new Map<string, string>(); // device csvName → room name
+  // deviceRoomPath: device → full room path string (e.g. "Studio A > Control Room")
+  const deviceRoomPath = new Map<string, string>();
   for (const c of connections) {
-    if (c.sourceRoom) deviceRoom.set(c.sourceDevice, c.sourceRoom);
-    if (c.destRoom) deviceRoom.set(c.destDevice, c.destRoom);
+    if (c.sourceRoom) deviceRoomPath.set(c.sourceDevice, c.sourceRoom);
+    if (c.destRoom) deviceRoomPath.set(c.destDevice, c.destRoom);
   }
+
+  // For layout grouping, use the full path as the band key (handles same-name subrooms)
+  const deviceRoom = new Map<string, string>();
+  for (const [device, path] of deviceRoomPath) deviceRoom.set(device, path);
 
   // Compute layout with size + room awareness
   const positions = autoLayout(connections, deviceNames, deviceSizes, deviceRoom);
 
-  // Create room nodes if rooms are specified
-  const roomMap = new Map<string, string>(); // room name → room node ID
-  const uniqueRooms = [...new Set(deviceRoom.values())];
-  for (const roomName of uniqueRooms) {
+  // Build all unique room paths including every ancestor prefix
+  // e.g. "A > B > C" → ["A", "A > B", "A > B > C"]
+  const allRoomPaths = new Set<string>();
+  for (const path of deviceRoomPath.values()) {
+    const parts = path.split(">").map((s) => s.trim()).filter(Boolean);
+    for (let i = 0; i < parts.length; i++) {
+      allRoomPaths.add(parts.slice(0, i + 1).join(" > "));
+    }
+  }
+
+  // Sort shallowest first so parents are created before children
+  const sortedPaths = [...allRoomPaths].sort(
+    (a, b) => a.split(">").length - b.split(">").length,
+  );
+
+  // roomPathMap: full path string → room node ID
+  const roomPathMap = new Map<string, string>();
+  for (const fullPath of sortedPaths) {
+    const parts = fullPath.split(">").map((s) => s.trim());
+    const label = parts[parts.length - 1];
+    const parentPath = parts.length > 1 ? parts.slice(0, -1).join(" > ") : undefined;
+    const parentRoomId = parentPath ? roomPathMap.get(parentPath) : undefined;
+
     const roomId = `room-import-${++importCounter}`;
-    roomMap.set(roomName, roomId);
-    // Room positioning will be computed after devices
+    roomPathMap.set(fullPath, roomId);
     nodes.push({
       id: roomId,
       type: "room",
       position: { x: 0, y: 0 },
-      data: { label: roomName },
+      data: {
+        label,
+        ...(parentRoomId ? { borderStyle: "solid" as const } : {}),
+      },
       style: { width: 400, height: 300 },
       zIndex: -1,
+      ...(parentRoomId ? { parentId: parentRoomId } : {}),
     } as SchematicNode);
   }
+
+  // Legacy alias so the device-creation code below can use roomPathMap uniformly
+  const roomMap = roomPathMap;
 
   // Create device nodes
   for (const name of deviceNames) {
@@ -595,7 +625,7 @@ export function buildImportResult(
       color = "#9ca3af"; // gray for generic
     }
 
-    const room = deviceRoom.get(name);
+    const room = deviceRoomPath.get(name);
     const parentId = room ? roomMap.get(room) : undefined;
 
     const node: DeviceNode = {
@@ -619,30 +649,61 @@ export function buildImportResult(
     deviceNodeMap.set(name, node);
   }
 
-  // Size room nodes to fit their children
-  for (const [, roomId] of roomMap) {
+  // Size room nodes to fit their children — process deepest rooms first so parent
+  // rooms can then be sized to contain their already-sized child rooms.
+  const roomDepthCache = new Map<string, number>();
+  function getRoomDepth(roomId: string): number {
+    if (roomDepthCache.has(roomId)) return roomDepthCache.get(roomId)!;
+    const room = nodes.find((n) => n.id === roomId);
+    const depth = room?.parentId ? 1 + getRoomDepth(room.parentId as string) : 0;
+    roomDepthCache.set(roomId, depth);
+    return depth;
+  }
+
+  const allRoomIds = [...roomPathMap.values()].sort(
+    (a, b) => getRoomDepth(b) - getRoomDepth(a), // deepest first
+  );
+
+  for (const roomId of allRoomIds) {
     const roomNode = nodes.find((n) => n.id === roomId);
     if (!roomNode) continue;
-    const children = nodes.filter((n) => n.type === "device" && (n as DeviceNode).parentId === roomId);
-    if (children.length === 0) continue;
+
+    const deviceChildren = nodes.filter(
+      (n) => n.type === "device" && (n as DeviceNode).parentId === roomId,
+    );
+    const roomChildren = nodes.filter(
+      (n) => n.type === "room" && n.parentId === roomId,
+    );
+
+    if (deviceChildren.length === 0 && roomChildren.length === 0) continue;
 
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    for (const child of children) {
-      const childData = (child as DeviceNode).data;
-      const h = estimateHeight(childData.ports);
+
+    for (const child of deviceChildren) {
+      const h = estimateHeight((child as DeviceNode).data.ports);
       minX = Math.min(minX, child.position.x);
       minY = Math.min(minY, child.position.y);
       maxX = Math.max(maxX, child.position.x + DEVICE_WIDTH);
       maxY = Math.max(maxY, child.position.y + h);
     }
 
-    const pad = 60; // generous padding for room label + routing space
+    for (const subroom of roomChildren) {
+      // subroom positions are still absolute at this point (not yet relativised)
+      const rw = (subroom.style as Record<string, number>).width ?? 400;
+      const rh = (subroom.style as Record<string, number>).height ?? 300;
+      minX = Math.min(minX, subroom.position.x);
+      minY = Math.min(minY, subroom.position.y);
+      maxX = Math.max(maxX, subroom.position.x + rw);
+      maxY = Math.max(maxY, subroom.position.y + rh);
+    }
+
+    const pad = 60;
     roomNode.position = { x: minX - pad, y: minY - pad };
     (roomNode.style as Record<string, number>).width = maxX - minX + pad * 2;
     (roomNode.style as Record<string, number>).height = maxY - minY + pad * 2;
 
-    // Convert child positions to room-relative
-    for (const child of children) {
+    // Convert direct children (devices + subrooms) to room-relative positions
+    for (const child of [...deviceChildren, ...roomChildren]) {
       child.position = {
         x: child.position.x - roomNode.position.x,
         y: child.position.y - roomNode.position.y,

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -13,7 +13,7 @@
 import { createDefaultLayout } from "./titleBlockLayout";
 import { DEFAULT_CONNECTOR } from "./connectorTypes";
 
-export const CURRENT_SCHEMA_VERSION = 23;
+export const CURRENT_SCHEMA_VERSION = 24;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Migration = (data: any) => any;
@@ -253,6 +253,13 @@ const migrations: Record<number, Migration> = {
   22: (data) => {
     // v22 → v23: autoRoute on SchematicFile — optional, defaults to true
     data.version = 23;
+    return data;
+  },
+  23: (data) => {
+    // v23 → v24: nested subrooms — rooms may now have a parentId pointing to
+    // another room. No data transform needed; parentId is already a valid
+    // React Flow node field and existing rooms simply have none.
+    data.version = 24;
     return data;
   },
 };

--- a/src/snapUtils.ts
+++ b/src/snapUtils.ts
@@ -572,7 +572,7 @@ export function speculativeReparent(
   node: SchematicNode,
   allNodes: SchematicNode[],
 ): SchematicNode {
-  if (node.parentId || node.type === "room") return node;
+  if (node.parentId) return node;
 
   const nodeW = node.measured?.width ?? 180;
   const nodeH = node.measured?.height ?? estimateDeviceHeight(node);

--- a/src/store.ts
+++ b/src/store.ts
@@ -168,6 +168,7 @@ interface SchematicState {
   updateRoomLabel: (nodeId: string, label: string) => void;
   updateRoom: (nodeId: string, data: import("./types").RoomData) => void;
   toggleRoomLock: (nodeId: string) => void;
+  toggleEquipmentRack: (nodeId: string) => void;
   addNote: (position: { x: number; y: number }) => void;
   updateNoteHtml: (nodeId: string, html: string) => void;
   reparentNode: (nodeId: string, absolutePosition: { x: number; y: number }) => void;
@@ -1546,6 +1547,25 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
           data: {
             ...n.data,
             locked: locked || undefined, // keep JSON clean
+          },
+        } as SchematicNode;
+      }),
+    });
+    get().saveToLocalStorage();
+  },
+
+  toggleEquipmentRack: (nodeId) => {
+    const state = get();
+    pushUndo({ nodes: state.nodes, edges: state.edges });
+    set({
+      nodes: state.nodes.map((n) => {
+        if (n.id !== nodeId || n.type !== "room") return n;
+        const wasRack = (n.data as import("./types").RoomData).isEquipmentRack;
+        return {
+          ...n,
+          data: {
+            ...n.data,
+            isEquipmentRack: wasRack ? undefined : true,
           },
         } as SchematicNode;
       }),

--- a/src/store.ts
+++ b/src/store.ts
@@ -581,15 +581,23 @@ function renumberNodes(nodes: SchematicNode[]): SchematicNode[] {
   });
 }
 
-/** Ensure parent (room) nodes appear before their children in the array. */
+/** Ensure parent nodes appear before their children in the array (topological sort). */
 function sortNodesParentFirst(nodes: SchematicNode[]): SchematicNode[] {
-  const rooms: SchematicNode[] = [];
-  const others: SchematicNode[] = [];
-  for (const n of nodes) {
-    if (n.type === "room") rooms.push(n);
-    else others.push(n);
+  const nodeMap = new Map(nodes.map((n) => [n.id, n]));
+  const result: SchematicNode[] = [];
+  const visited = new Set<string>();
+
+  function visit(n: SchematicNode) {
+    if (visited.has(n.id)) return;
+    if (n.parentId && nodeMap.has(n.parentId)) visit(nodeMap.get(n.parentId)!);
+    visited.add(n.id);
+    result.push(n);
   }
-  return [...rooms, ...others];
+
+  // Visit rooms first so all rooms precede non-room nodes
+  for (const n of nodes) if (n.type === "room") visit(n);
+  for (const n of nodes) if (n.type !== "room") visit(n);
+  return result;
 }
 
 function getPortFromHandle(
@@ -1002,6 +1010,16 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
         .map((n) => n.id),
     );
 
+    // Build a map for absolute position resolution (needed for multi-level nesting)
+    const nodeMap = new Map(state.nodes.map((n) => [n.id, n]));
+    function computeAbsolutePos(nId: string): { x: number; y: number } {
+      const n = nodeMap.get(nId);
+      if (!n) return { x: 0, y: 0 };
+      if (!n.parentId) return n.position;
+      const p = computeAbsolutePos(n.parentId);
+      return { x: n.position.x + p.x, y: n.position.y + p.y };
+    }
+
     // Also remove edges connected to deleted nodes
     const newEdges = state.edges.filter(
       (e) =>
@@ -1014,15 +1032,12 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
       .filter((n) => !n.selected)
       .map((n) => {
         if (n.parentId && deletedRoomIds.has(n.parentId)) {
-          // Convert to absolute position
-          const room = state.nodes.find((r) => r.id === n.parentId);
+          // Convert to absolute position — walk the full parent chain
           return {
             ...n,
             parentId: undefined,
             extent: undefined,
-            position: room
-              ? { x: n.position.x + room.position.x, y: n.position.y + room.position.y }
-              : n.position,
+            position: computeAbsolutePos(n.id),
           };
         }
         return n;
@@ -1045,12 +1060,21 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
   },
 
   deleteNodeAndChildren: (nodeId: string) => {
-    // Select this node and all its children, then removeSelected
+    // Collect all descendants recursively (handles nested subrooms)
+    const nodes = get().nodes;
+    const toDelete = new Set<string>([nodeId]);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const n of nodes) {
+        if (!toDelete.has(n.id) && n.parentId && toDelete.has(n.parentId)) {
+          toDelete.add(n.id);
+          changed = true;
+        }
+      }
+    }
     set({
-      nodes: get().nodes.map((n) => ({
-        ...n,
-        selected: n.id === nodeId || n.parentId === nodeId,
-      })),
+      nodes: nodes.map((n) => ({ ...n, selected: toDelete.has(n.id) })),
       edges: get().edges.map((e) => ({ ...e, selected: false })),
     });
     get().removeSelected();
@@ -1557,22 +1581,46 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
   reparentNode: (nodeId, absolutePosition) => {
     const state = get();
     const node = state.nodes.find((n) => n.id === nodeId);
-    if (!node || node.type === "room") return;
+    if (!node) return;
 
-    // Find which room (if any) the node's center falls inside
-    const nodeW = node.measured?.width ?? 180;
-    const nodeH = node.measured?.height ?? 60;
+    const nodeMap = new Map(state.nodes.map((n) => [n.id, n]));
+
+    /** Compute the full absolute canvas position of a node by walking its parent chain. */
+    function getAbsolutePosition(nId: string): { x: number; y: number } {
+      const n = nodeMap.get(nId);
+      if (!n) return { x: 0, y: 0 };
+      if (!n.parentId) return n.position;
+      const p = getAbsolutePosition(n.parentId);
+      return { x: n.position.x + p.x, y: n.position.y + p.y };
+    }
+
+    /** True if ancestorId is an ancestor of childId (prevents circular nesting). */
+    function isAncestorOf(ancestorId: string, childId: string): boolean {
+      let cur = nodeMap.get(childId);
+      while (cur?.parentId) {
+        if (cur.parentId === ancestorId) return true;
+        cur = nodeMap.get(cur.parentId);
+      }
+      return false;
+    }
+
+    const isRoom = node.type === "room";
+    const nodeW = node.measured?.width ?? (isRoom ? 400 : 180);
+    const nodeH = node.measured?.height ?? (isRoom ? 300 : 60);
     const centerX = absolutePosition.x + nodeW / 2;
     const centerY = absolutePosition.y + nodeH / 2;
 
     let targetRoom: SchematicNode | undefined;
     for (const n of state.nodes) {
       if (n.type !== "room") continue;
+      if (n.id === nodeId) continue; // can't parent to itself
+      if (isRoom && isAncestorOf(nodeId, n.id)) continue; // prevent circular nesting
       const rw = n.measured?.width ?? (n.style?.width as number) ?? (n.width as number) ?? 400;
       const rh = n.measured?.height ?? (n.style?.height as number) ?? (n.height as number) ?? 300;
+      const absPos = getAbsolutePosition(n.id);
       if (
-        centerX >= n.position.x && centerX <= n.position.x + rw &&
-        centerY >= n.position.y && centerY <= n.position.y + rh
+        centerX >= absPos.x && centerX <= absPos.x + rw &&
+        centerY >= absPos.y && centerY <= absPos.y + rh
       ) {
         targetRoom = n;
         break;
@@ -1589,13 +1637,14 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
     let updated = state.nodes.map((n) => {
       if (n.id !== nodeId) return n;
       if (newParent && targetRoom) {
-        // Reparent into room — convert to relative position
+        // Reparent — convert to position relative to new parent
+        const targetAbsPos = getAbsolutePosition(targetRoom.id);
         return {
           ...n,
           parentId: newParent,
           position: {
-            x: absolutePosition.x - targetRoom.position.x,
-            y: absolutePosition.y - targetRoom.position.y,
+            x: absolutePosition.x - targetAbsPos.x,
+            y: absolutePosition.y - targetAbsPos.y,
           },
         };
       } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -204,6 +204,7 @@ export interface RoomData {
   borderStyle?: "dashed" | "solid" | "dotted";
   labelSize?: number;
   locked?: boolean;
+  isEquipmentRack?: boolean;
 }
 
 export type RoomNode = Node<RoomData, "room">;


### PR DESCRIPTION
## Nested Subrooms + Equipment Rack Toggle

**Overview**
This PR introduces two related features: the ability to nest rooms inside other rooms (subrooms), and a per-subroom toggle to mark a nested room as an equipment rack.

isEquipmentRack data doesnt really do anything yet outside of the visual changes and value stored to RoomData, hopefully to be used down the road for rack management features.

**Testing**
FYI This is a pretty Claude heavy PR. I have worked through any edge cases I could think of and have tested functionalities on a local docker instance.

**Nested Subrooms**
Rooms can now be dragged inside other rooms to create a parent/child hierarchy. Drag a room into another to nest it; drag it back out to un-parent it.


**What changed:**

- Removed the three explicit type === "room" guards that previously blocked rooms from being reparented (in App.tsx, store.ts, and snapUtils.ts)

- reparentNode now handles rooms with circular-nesting prevention — dropping a room into one of its own descendants is a no-op

- Absolute position resolution walks the full ancestor chain, so nesting works at arbitrary depth

- Subrooms render with a solid border and slightly more opaque background to visually distinguish them from top-level rooms

- CSV import supports Parent Room > Child Room > Grandchild Room path syntax in Source/Dest Room columns, creating the full hierarchy automatically

**CSV import layout fixes (nested rooms):**

- Room bands were previously ordered by CSV row insertion, which could interleave bands from different parent rooms and cause parent room nodes to overlap. Bands are now sorted hierarchically so all paths under the same top-level room are consecutive.

- Parent room padding (60px top + bottom) exceeded ORIGIN_PAD, placing parent rooms at negative canvas coordinates. A post-sizing normalization pass now stacks top-level rooms cleanly and anchors them at (40, 40).

**Equipment Rack Toggle**
Nested rooms can be marked as equipment racks.

**What changed:**

- isEquipmentRack?: boolean added to RoomData

- toggleEquipmentRack store action

- Right-click context menu: "Mark as Equipment Rack" / "Remove Equipment Rack" — only appears on nested rooms

- Edit Properties dialog: "Equipment Rack: Yes / No" toggle — only shown when the room has a parent

- Visual treatment: solid border, darker grey background tint, small rack icon next to the room label