### PR TITLE
Add Auxiliary Data Block at bottom of device

### DIFF
--- a/src/components/DeviceEditor.tsx
+++ b/src/components/DeviceEditor.tsx
@@ -103,6 +103,9 @@ export default function DeviceEditor() {
   const [isVenueProvided, setIsVenueProvided] = useState(false);
   const [adapterVisibility, setAdapterVisibility] = useState<"default" | "force-show" | "force-hide">("default");
 
+  // Auxiliary data lines
+  const [auxiliaryData, setAuxiliaryData] = useState<string[]>([]);
+
   // Login dialog for community submission
   const [showLoginDialog, setShowLoginDialog] = useState(false);
 
@@ -151,6 +154,7 @@ export default function DeviceEditor() {
     setIntegratedWithCable(node.data.integratedWithCable ?? false);
     setIsVenueProvided(node.data.isVenueProvided ?? false);
     setAdapterVisibility(node.data.adapterVisibility ?? "default");
+    setAuxiliaryData(node.data.auxiliaryData ?? []);
   }, [node]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
@@ -204,10 +208,11 @@ export default function DeviceEditor() {
       ...(adapterVisibility !== "default" ? { adapterVisibility } : {}),
       ...(existing?.baseLabel ? { baseLabel: existing.baseLabel } : {}),
       ...(existing?.slots ? { slots: existing.slots } : {}),
+      ...(auxiliaryData.filter((line) => line.trim()).length > 0 ? { auxiliaryData: auxiliaryData.filter((line) => line.trim()) } : {}),
     };
     updateDevice(editingNodeId, data);
     close();
-  }, [editingNodeId, ports, label, hostname, deviceType, color, headerColor, node, updateDevice, close, showAllPorts, hiddenPorts, dhcpServer, powerDrawW, powerCapacityW, voltage, poeBudgetW, unitCost, isCableAccessory, integratedWithCable, isVenueProvided, adapterVisibility]);
+  }, [editingNodeId, ports, label, hostname, deviceType, color, headerColor, node, updateDevice, close, showAllPorts, hiddenPorts, dhcpServer, powerDrawW, powerCapacityW, voltage, poeBudgetW, unitCost, isCableAccessory, integratedWithCable, isVenueProvided, adapterVisibility, auxiliaryData]);
 
   // Ctrl+Enter anywhere in the editor → Apply & Close
   const onCtrlEnter = useCallback((e: React.KeyboardEvent) => {
@@ -785,6 +790,31 @@ export default function DeviceEditor() {
                 step={0.01}
                 onKeyDown={(e) => e.stopPropagation()}
               />
+            </div>
+          </details>
+
+          {/* Auxiliary Data */}
+          <details className="text-xs">
+            <summary className="cursor-pointer text-[var(--color-text-secondary)] hover:text-[var(--color-text)] select-none py-1">
+              Auxiliary Data
+            </summary>
+            <div className="flex flex-col gap-1.5 pt-1 pl-2">
+              <p className="text-[10px] text-[var(--color-text-muted)] -mb-0.5">Up to 5 custom lines (displayed at bottom of device)</p>
+              {[0, 1, 2, 3, 4].map((i) => (
+                <input
+                  key={i}
+                  type="text"
+                  className="w-full bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2 py-1 text-xs outline-none focus:border-blue-500"
+                  value={auxiliaryData[i] ?? ""}
+                  onChange={(e) => {
+                    const newData = [...auxiliaryData];
+                    newData[i] = e.target.value;
+                    setAuxiliaryData(newData);
+                  }}
+                  placeholder={`Auxiliary Data`}
+                  onKeyDown={(e) => e.stopPropagation()}
+                />
+              ))}
             </div>
           </details>
 

--- a/src/components/DeviceNode.tsx
+++ b/src/components/DeviceNode.tsx
@@ -405,6 +405,19 @@ function DeviceNodeComponent({ id, data, selected }: NodeProps<DeviceNodeType>) 
           })}
         </div>
       )}
+      {data.auxiliaryData?.length ? (
+        <div className="auxiliaryData px-3 py-2 border-t border-[var(--color-border)]">
+          {data.auxiliaryData.map((line, i) => (
+            <div
+              key={i}
+              className="text-[9px] text-[var(--color-text-muted)] leading-4 truncate whitespace-nowrap text-center"
+              title={line}
+            >
+              {line}
+            </div>
+          ))}
+        </div>
+      ) : null}
       </div>
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,8 @@ export interface DeviceData {
   isVenueProvided?: boolean;
   /** Adapter visibility override — only meaningful for deviceType "adapter" */
   adapterVisibility?: "default" | "force-show" | "force-hide";
+  /** User-customizable auxiliary data lines (up to 5) displayed at bottom of device node */
+  auxiliaryData?: string[];
 }
 
 export type DeviceNode = Node<DeviceData, "device">;


### PR DESCRIPTION
## Description

This change allows users to add "auxiliary data" to the bottom of device blocks to note information like IP addresses, rack locations, or other important notes.  Auxiliary Data lines are currently capped at 5.

## Screenshots
<img width="650" height="846" alt="image" src="https://github.com/user-attachments/assets/9c807f7c-a466-449e-8ed5-468f113ed61e" />