### PR TITLE
Auto populate manufacturer

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1075,6 +1075,13 @@ app.get("/templates/device-types", async (c) => {
   return c.json(results.map((r) => (r as { device_type: string }).device_type), 200, CACHE_HEADERS);
 });
 
+app.get("/templates/manufacturers", async (c) => {
+  const { results } = await c.env.easyschematic_db
+    .prepare("SELECT DISTINCT manufacturer FROM templates WHERE manufacturer IS NOT NULL ORDER BY manufacturer")
+    .all();
+  return c.json(results.map((r) => (r as { manufacturer: string }).manufacturer), 200, CACHE_HEADERS);
+});
+
 app.get("/templates/search-terms", async (c) => {
   const { results } = await c.env.easyschematic_db
     .prepare("SELECT search_terms FROM templates WHERE search_terms IS NOT NULL")

--- a/devices/src/api.ts
+++ b/devices/src/api.ts
@@ -54,6 +54,12 @@ export async function fetchSearchTerms(): Promise<string[]> {
   return res.json();
 }
 
+export async function fetchManufacturers(): Promise<string[]> {
+  const res = await fetch(`${API_URL}/templates/manufacturers`);
+  if (!res.ok) return [];
+  return res.json();
+}
+
 // ==================== DRAFTS ====================
 
 export async function fetchDraft(id: string): Promise<Record<string, unknown>> {

--- a/devices/src/components/DeviceForm.tsx
+++ b/devices/src/components/DeviceForm.tsx
@@ -3,6 +3,7 @@ import type { Port, SlotDefinition, DeviceTemplate } from "../../../src/types";
 import { fetchTemplate, fetchSearchTerms, fetchTemplates, fetchDraft, fetchManufacturers } from "../api";
 import { linkClick } from "../navigate";
 import PortEditor from "./PortEditor";
+import AutocompleteInput from "./AutocompleteInput";
 import SearchableSelect from "./SearchableSelect";
 import TagInput from "./TagInput";
 import { DEVICE_TYPE_TO_CATEGORY, DEVICE_TYPE_LABELS, ALL_CATEGORIES, DEVICE_TYPES_BY_CATEGORY } from "../../../src/deviceTypeCategories";

--- a/devices/src/components/DeviceForm.tsx
+++ b/devices/src/components/DeviceForm.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, type ReactNode } from "react";
 import type { Port, SlotDefinition, DeviceTemplate } from "../../../src/types";
-import { fetchTemplate, fetchSearchTerms, fetchTemplates, fetchDraft } from "../api";
+import { fetchTemplate, fetchSearchTerms, fetchTemplates, fetchDraft, fetchManufacturers } from "../api";
 import { linkClick } from "../navigate";
 import PortEditor from "./PortEditor";
 import SearchableSelect from "./SearchableSelect";
@@ -72,11 +72,13 @@ export default function DeviceForm({ id, draftId, onSubmit, submitLabel = "Save"
   const [customDeviceType, setCustomDeviceType] = useState(false);
   const [customDeviceTypeText, setCustomDeviceTypeText] = useState("");
   const [knownSearchTerms, setKnownSearchTerms] = useState<string[]>([]);
+  const [knownManufacturers, setKnownManufacturers] = useState<string[]>([]);
   const [allTemplates, setAllTemplates] = useState<DeviceTemplate[]>([]);
   const categoryAutoRef = useRef(true);
 
   useEffect(() => {
     fetchSearchTerms().then(setKnownSearchTerms);
+    fetchManufacturers().then(setKnownManufacturers);
     fetchTemplates().then(setAllTemplates).catch(() => {});
   }, []);
 
@@ -282,7 +284,7 @@ export default function DeviceForm({ id, draftId, onSubmit, submitLabel = "Save"
         </div>
         <label>
           <span className="block text-sm font-medium text-slate-700 mb-1">Manufacturer *</span>
-          <input value={manufacturer} onChange={(e) => setManufacturer(e.target.value)} placeholder="e.g. Blackmagic Design, or Generic" className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          <AutocompleteInput value={manufacturer} onChange={setManufacturer} suggestions={knownManufacturers} placeholder="e.g. Blackmagic Design, or Generic" className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
         </label>
         <label>
           <span className="block text-sm font-medium text-slate-700 mb-1">Model Number {!isGenericMfr ? "*" : ""}</span>

--- a/devices/src/components/TagInput.tsx
+++ b/devices/src/components/TagInput.tsx
@@ -32,6 +32,7 @@ export default function TagInput({ tags, onChange, suggestions = [], autoSuggest
 
   const show = open && filtered.length > 0;
 
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: reset keyboard index when input value changes
   useEffect(() => { setActiveIdx(-1); }, [input]);
 
   useEffect(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2512,9 +2512,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2532,9 +2529,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2552,9 +2546,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2572,9 +2563,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2592,9 +2580,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2612,9 +2597,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2632,9 +2614,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2652,9 +2631,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2672,9 +2648,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2698,9 +2671,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2724,9 +2694,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2750,9 +2717,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2776,9 +2740,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2802,9 +2763,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2828,9 +2786,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2854,9 +2809,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3195,9 +3147,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3215,9 +3164,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3235,9 +3181,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3255,9 +3198,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3275,9 +3215,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3295,9 +3232,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3762,9 +3696,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3786,9 +3717,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3810,9 +3738,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3834,9 +3759,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4009,9 +3931,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4029,9 +3948,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4049,9 +3965,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4069,9 +3982,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7666,9 +7576,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7690,9 +7597,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7714,9 +7618,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7738,9 +7639,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Add manufacturer autocomplete to device submission form

Addresses the problem of duplicate manufacturer names in the device database (e.g. "Grass Valley" vs "Grassvalley") by surfacing existing manufacturer names as suggestions while a user types.

## Changes:

- GET /templates/manufacturers — new API endpoint returning distinct, sorted manufacturer names from the database (same pattern as /templates/categories and /templates/device-types)

- fetchManufacturers() — added to the frontend API client alongside the existing fetchSearchTerms() fetch

- Manufacturer field in the device submission form now uses AutocompleteInput with live suggestions from the database — type "RTS" and you'll see "RTS Intercom Systems" before committing to a new name

- Fixed missing AutocompleteInput import that was left out of the form overhaul (#122 , which seemed to have broken the manufacturer field

- Fixed pre-existing eslint-disable omission in TagInput.tsx (same intentional pattern already suppressed in AutocompleteInput.tsx)

- Behaviour: Free-text field — users can still enter any manufacturer name. Suggestions only appear when there's a partial match against existing names, and disappear once an exact match is selected. This behavior just like when a user types in the search term field.