### PR TITLE
Add rack prop fields to device nodes

### DIFF
--- a/devices/src/components/DeviceForm.tsx
+++ b/devices/src/components/DeviceForm.tsx
@@ -25,6 +25,9 @@ export interface DeviceFormData {
   powerCapacityW?: number;
   voltage?: string;
   poeBudgetW?: number;
+  rackHeightU?: number;
+  rackDepthMm?: number;
+  weight?: number;
   isVenueProvided?: boolean;
   submitterNote?: string;
 }
@@ -62,6 +65,9 @@ export default function DeviceForm({ id, draftId, onSubmit, submitLabel = "Save"
   const [powerCapacityW, setPowerCapacityW] = useState<string>("");
   const [voltage, setVoltage] = useState("");
   const [poeBudgetW, setPoeBudgetW] = useState<string>("");
+  const [rackHeightU, setRackHeightU] = useState<string>("");
+  const [rackDepthMm, setRackDepthMm] = useState<string>("");
+  const [weight, setWeight] = useState<string>("");
   const [isVenueProvided, setIsVenueProvided] = useState(false);
   const [submitterNote, setSubmitterNote] = useState("");
   const [loading, setLoading] = useState(!!id);
@@ -108,6 +114,9 @@ export default function DeviceForm({ id, draftId, onSubmit, submitLabel = "Save"
         setPowerCapacityW(t.powerCapacityW != null ? String(t.powerCapacityW) : "");
         setVoltage(t.voltage ?? "");
         setPoeBudgetW(t.poeBudgetW != null ? String(t.poeBudgetW) : "");
+        setRackHeightU(t.rackHeightU != null ? String(t.rackHeightU) : "");
+        setRackDepthMm(t.rackDepthMm != null ? String(t.rackDepthMm) : "");
+        setWeight(t.weight != null ? String(t.weight) : "");
         setIsVenueProvided((t as DeviceTemplate & { isVenueProvided?: boolean }).isVenueProvided ?? false);
       })
       .catch((e) => setError(e.message))
@@ -134,6 +143,9 @@ export default function DeviceForm({ id, draftId, onSubmit, submitLabel = "Save"
         setPowerCapacityW(t.powerCapacityW != null ? String(t.powerCapacityW) : "");
         setVoltage((t.voltage as string) ?? "");
         setPoeBudgetW(t.poeBudgetW != null ? String(t.poeBudgetW) : "");
+        setRackHeightU(t.rackHeightU != null ? String(t.rackHeightU) : "");
+        setRackDepthMm(t.rackDepthMm != null ? String(t.rackDepthMm) : "");
+        setWeight(t.weight != null ? String(t.weight) : "");
       })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
@@ -178,6 +190,9 @@ export default function DeviceForm({ id, draftId, onSubmit, submitLabel = "Save"
         ...(powerCapacityW.trim() && { powerCapacityW: Number(powerCapacityW) }),
         ...(voltage.trim() && { voltage: voltage.trim() }),
         ...(poeBudgetW.trim() && { poeBudgetW: Number(poeBudgetW) }),
+        ...(rackHeightU.trim() && { rackHeightU: Number(rackHeightU) }),
+        ...(rackDepthMm.trim() && { rackDepthMm: Number(rackDepthMm) }),
+        ...(weight.trim() && { weight: Number(weight) }),
         ...(isVenueProvided && { isVenueProvided: true }),
         ...(() => {
           const parts: string[] = [];
@@ -319,6 +334,21 @@ export default function DeviceForm({ id, draftId, onSubmit, submitLabel = "Save"
         <label>
           <span className="block text-sm font-medium text-slate-700 mb-1">Voltage</span>
           <input value={voltage} onChange={(e) => setVoltage(e.target.value)} placeholder="e.g. 100-240V" className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        </label>
+        <label>
+          <span className="block text-sm font-medium text-slate-700 mb-1">Rack Height (U)</span>
+          <input type="number" min="0.25" step="0.25" value={rackHeightU} onChange={(e) => setRackHeightU(e.target.value)} placeholder="e.g. 1" className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          <span className="text-xs text-slate-400 mt-1 block">Height in rack units from spec sheet</span>
+        </label>
+        <label>
+          <span className="block text-sm font-medium text-slate-700 mb-1">Rack Depth (mm)</span>
+          <input type="number" min="1" value={rackDepthMm} onChange={(e) => setRackDepthMm(e.target.value)} placeholder="e.g. 482" className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          <span className="text-xs text-slate-400 mt-1 block">Chassis depth from spec sheet</span>
+        </label>
+        <label>
+          <span className="block text-sm font-medium text-slate-700 mb-1">Weight (kg)</span>
+          <input type="number" min="0" step="0.1" value={weight} onChange={(e) => setWeight(e.target.value)} placeholder="e.g. 2.5" className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+          <span className="text-xs text-slate-400 mt-1 block">Device weight from spec sheet</span>
         </label>
         <label className="flex items-center gap-2 cursor-pointer">
           <input type="checkbox" checked={isVenueProvided} onChange={(e) => setIsVenueProvided(e.target.checked)} className="cursor-pointer" />

--- a/src/components/DeviceEditor.tsx
+++ b/src/components/DeviceEditor.tsx
@@ -99,6 +99,7 @@ export default function DeviceEditor() {
 
   // Rack
   const [rackU, setRackU] = useState<number | undefined>(undefined);
+  const [rackUCustom, setRackUCustom] = useState(false);
 
   // Cable accessory flags
   const [isCableAccessory, setIsCableAccessory] = useState(false);
@@ -153,7 +154,10 @@ export default function DeviceEditor() {
     setVoltage(node.data.voltage);
     setPoeBudgetW(node.data.poeBudgetW);
     setUnitCost(node.data.unitCost);
+    const RACK_U_PRESETS = [0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+    const isCustomRackU = node.data.rackU != null && !RACK_U_PRESETS.includes(node.data.rackU);
     setRackU(node.data.rackU);
+    setRackUCustom(isCustomRackU);
     setIsCableAccessory(node.data.isCableAccessory ?? false);
     setIntegratedWithCable(node.data.integratedWithCable ?? false);
     setIsVenueProvided(node.data.isVenueProvided ?? false);
@@ -674,14 +678,34 @@ export default function DeviceEditor() {
             <span className="text-[10px] text-[var(--color-text-muted)] shrink-0">Rack U:</span>
             <select
               className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs outline-none focus:border-blue-500"
-              value={rackU ?? ""}
-              onChange={(e) => setRackU(e.target.value ? Number(e.target.value) : undefined)}
+              value={rackUCustom ? "custom" : (rackU != null ? String(rackU) : "")}
+              onChange={(e) => {
+                const val = e.target.value;
+                if (val === "") { setRackUCustom(false); setRackU(undefined); }
+                else if (val === "custom") { setRackUCustom(true); setRackU(undefined); }
+                else { setRackUCustom(false); setRackU(Number(val)); }
+              }}
             >
               <option value="">—</option>
-              {[0.5, 1, 2, 3, 4, 6, 8, 10, 12, 14, 16, 20, 28, 40].map((u) => (
-                <option key={u} value={u}>{u === 0.5 ? "½U" : `${u}U`}</option>
+              {([0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const).map((u) => (
+                <option key={u} value={u}>
+                  {u === 0.25 ? "¼U" : u === 0.5 ? "½U" : `${u}U`}
+                </option>
               ))}
+              <option value="custom">Custom</option>
             </select>
+            {rackUCustom && (
+              <input
+                type="number"
+                className="w-16 bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs outline-none focus:border-blue-500"
+                value={rackU ?? ""}
+                onChange={(e) => setRackU(e.target.value ? Number(e.target.value) : undefined)}
+                placeholder="e.g. 14"
+                min={0.25}
+                step={0.25}
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+            )}
             <span className="text-[10px] text-[var(--color-text-muted)] shrink-0 ml-2">Hostname:</span>
             <input
               className="flex-1 bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs outline-none focus:border-blue-500"

--- a/src/components/DeviceEditor.tsx
+++ b/src/components/DeviceEditor.tsx
@@ -99,7 +99,6 @@ export default function DeviceEditor() {
 
   // Rack
   const [rackHeightU, setRackHeightU] = useState<number | undefined>(undefined);
-  const [rackHeightUCustom, setRackHeightUCustom] = useState(false);
   const [rackDepthMm, setRackDepthMm] = useState<number | undefined>(undefined);
   const [weight, setWeight] = useState<number | undefined>(undefined);
 
@@ -156,10 +155,7 @@ export default function DeviceEditor() {
     setVoltage(node.data.voltage);
     setPoeBudgetW(node.data.poeBudgetW);
     setUnitCost(node.data.unitCost);
-    const RACK_U_PRESETS = [0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-    const isCustomRackU = node.data.rackHeightU != null && !RACK_U_PRESETS.includes(node.data.rackHeightU);
     setRackHeightU(node.data.rackHeightU);
-    setRackHeightUCustom(isCustomRackU);
     setRackDepthMm(node.data.rackDepthMm);
     setWeight(node.data.weight);
     setIsCableAccessory(node.data.isCableAccessory ?? false);
@@ -227,7 +223,7 @@ export default function DeviceEditor() {
     };
     updateDevice(editingNodeId, data);
     close();
-  }, [editingNodeId, ports, label, hostname, deviceType, color, headerColor, node, updateDevice, close, showAllPorts, hiddenPorts, dhcpServer, powerDrawW, powerCapacityW, voltage, poeBudgetW, unitCost, rackHeightU, rackHeightUCustom, rackDepthMm, weight, isCableAccessory, integratedWithCable, isVenueProvided, adapterVisibility, auxiliaryData]);
+  }, [editingNodeId, ports, label, hostname, deviceType, color, headerColor, node, updateDevice, close, showAllPorts, hiddenPorts, dhcpServer, powerDrawW, powerCapacityW, voltage, poeBudgetW, unitCost, rackHeightU, rackDepthMm, weight, isCableAccessory, integratedWithCable, isVenueProvided, adapterVisibility, auxiliaryData]);
 
   // Ctrl+Enter anywhere in the editor → Apply & Close
   const onCtrlEnter = useCallback((e: React.KeyboardEvent) => {
@@ -701,38 +697,17 @@ export default function DeviceEditor() {
                 <label className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-0.5">
                   Height
                 </label>
-                <div className="flex items-center gap-1">
-                  <select
-                    className="flex-1 bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-1 text-xs outline-none focus:border-blue-500"
-                    value={rackHeightUCustom ? "custom" : (rackHeightU != null ? String(rackHeightU) : "")}
-                    onChange={(e) => {
-                      const val = e.target.value;
-                      if (val === "") { setRackHeightUCustom(false); setRackHeightU(undefined); }
-                      else if (val === "custom") { setRackHeightUCustom(true); setRackHeightU(undefined); }
-                      else { setRackHeightUCustom(false); setRackHeightU(Number(val)); }
-                    }}
-                  >
-                    <option value="">—</option>
-                    {([0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const).map((u) => (
-                      <option key={u} value={u}>
-                        {u === 0.25 ? "¼U" : u === 0.5 ? "½U" : `${u}U`}
-                      </option>
-                    ))}
-                    <option value="custom">Custom</option>
-                  </select>
-                </div>
-                {rackHeightUCustom && (
-                  <input
-                    type="number"
-                    className="mt-1 w-full bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-1 text-xs outline-none focus:border-blue-500"
-                    value={rackHeightU ?? ""}
-                    onChange={(e) => setRackHeightU(e.target.value ? Number(e.target.value) : undefined)}
-                    placeholder="e.g. 14"
-                    min={1}
-                    step={1}
-                    onKeyDown={(e) => e.stopPropagation()}
-                  />
-                )}
+                <input
+                  type="number"
+                  className="w-full bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-1 text-xs outline-none focus:border-blue-500"
+                  value={rackHeightU ?? ""}
+                  onChange={(e) => setRackHeightU(e.target.value ? Number(e.target.value) : undefined)}
+                  placeholder="e.g. 2"
+                  min={1}
+                  max={20}
+                  step={1}
+                  onKeyDown={(e) => e.stopPropagation()}
+                />
               </div>
               <div>
                 <label className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-0.5">

--- a/src/components/DeviceEditor.tsx
+++ b/src/components/DeviceEditor.tsx
@@ -701,8 +701,8 @@ export default function DeviceEditor() {
                 value={rackU ?? ""}
                 onChange={(e) => setRackU(e.target.value ? Number(e.target.value) : undefined)}
                 placeholder="e.g. 14"
-                min={0.25}
-                step={0.25}
+                min={1}
+                step={1}
                 onKeyDown={(e) => e.stopPropagation()}
               />
             )}

--- a/src/components/DeviceEditor.tsx
+++ b/src/components/DeviceEditor.tsx
@@ -97,6 +97,9 @@ export default function DeviceEditor() {
   // Cost
   const [unitCost, setUnitCost] = useState<number | undefined>(undefined);
 
+  // Rack
+  const [rackU, setRackU] = useState<number | undefined>(undefined);
+
   // Cable accessory flags
   const [isCableAccessory, setIsCableAccessory] = useState(false);
   const [integratedWithCable, setIntegratedWithCable] = useState(false);
@@ -150,6 +153,7 @@ export default function DeviceEditor() {
     setVoltage(node.data.voltage);
     setPoeBudgetW(node.data.poeBudgetW);
     setUnitCost(node.data.unitCost);
+    setRackU(node.data.rackU);
     setIsCableAccessory(node.data.isCableAccessory ?? false);
     setIntegratedWithCable(node.data.integratedWithCable ?? false);
     setIsVenueProvided(node.data.isVenueProvided ?? false);
@@ -202,6 +206,7 @@ export default function DeviceEditor() {
       ...(poeBudgetW != null ? { poeBudgetW } : {}),
       ...(voltage ? { voltage } : {}),
       ...(unitCost != null ? { unitCost } : {}),
+      ...(rackU != null ? { rackU } : {}),
       ...(isCableAccessory ? { isCableAccessory: true } : {}),
       ...(integratedWithCable ? { integratedWithCable: true } : {}),
       ...(isVenueProvided ? { isVenueProvided: true } : {}),
@@ -212,7 +217,7 @@ export default function DeviceEditor() {
     };
     updateDevice(editingNodeId, data);
     close();
-  }, [editingNodeId, ports, label, hostname, deviceType, color, headerColor, node, updateDevice, close, showAllPorts, hiddenPorts, dhcpServer, powerDrawW, powerCapacityW, voltage, poeBudgetW, unitCost, isCableAccessory, integratedWithCable, isVenueProvided, adapterVisibility, auxiliaryData]);
+  }, [editingNodeId, ports, label, hostname, deviceType, color, headerColor, node, updateDevice, close, showAllPorts, hiddenPorts, dhcpServer, powerDrawW, powerCapacityW, voltage, poeBudgetW, unitCost, rackU, rackUCustom, isCableAccessory, integratedWithCable, isVenueProvided, adapterVisibility, auxiliaryData]);
 
   // Ctrl+Enter anywhere in the editor → Apply & Close
   const onCtrlEnter = useCallback((e: React.KeyboardEvent) => {
@@ -664,9 +669,20 @@ export default function DeviceEditor() {
             setHiddenPorts={setHiddenPorts}
           />
 
-          {/* Hostname */}
+          {/* Hostname + Rack U */}
           <div className="flex items-center gap-2 mt-2">
-            <span className="text-[10px] text-[var(--color-text-muted)]">Hostname:</span>
+            <span className="text-[10px] text-[var(--color-text-muted)] shrink-0">Rack U:</span>
+            <select
+              className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs outline-none focus:border-blue-500"
+              value={rackU ?? ""}
+              onChange={(e) => setRackU(e.target.value ? Number(e.target.value) : undefined)}
+            >
+              <option value="">—</option>
+              {[0.5, 1, 2, 3, 4, 6, 8, 10, 12, 14, 16, 20, 28, 40].map((u) => (
+                <option key={u} value={u}>{u === 0.5 ? "½U" : `${u}U`}</option>
+              ))}
+            </select>
+            <span className="text-[10px] text-[var(--color-text-muted)] shrink-0 ml-2">Hostname:</span>
             <input
               className="flex-1 bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs outline-none focus:border-blue-500"
               value={hostname}

--- a/src/components/DeviceEditor.tsx
+++ b/src/components/DeviceEditor.tsx
@@ -98,8 +98,10 @@ export default function DeviceEditor() {
   const [unitCost, setUnitCost] = useState<number | undefined>(undefined);
 
   // Rack
-  const [rackU, setRackU] = useState<number | undefined>(undefined);
-  const [rackUCustom, setRackUCustom] = useState(false);
+  const [rackHeightU, setRackHeightU] = useState<number | undefined>(undefined);
+  const [rackHeightUCustom, setRackHeightUCustom] = useState(false);
+  const [rackDepthMm, setRackDepthMm] = useState<number | undefined>(undefined);
+  const [weight, setWeight] = useState<number | undefined>(undefined);
 
   // Cable accessory flags
   const [isCableAccessory, setIsCableAccessory] = useState(false);
@@ -155,9 +157,11 @@ export default function DeviceEditor() {
     setPoeBudgetW(node.data.poeBudgetW);
     setUnitCost(node.data.unitCost);
     const RACK_U_PRESETS = [0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-    const isCustomRackU = node.data.rackU != null && !RACK_U_PRESETS.includes(node.data.rackU);
-    setRackU(node.data.rackU);
-    setRackUCustom(isCustomRackU);
+    const isCustomRackU = node.data.rackHeightU != null && !RACK_U_PRESETS.includes(node.data.rackHeightU);
+    setRackHeightU(node.data.rackHeightU);
+    setRackHeightUCustom(isCustomRackU);
+    setRackDepthMm(node.data.rackDepthMm);
+    setWeight(node.data.weight);
     setIsCableAccessory(node.data.isCableAccessory ?? false);
     setIntegratedWithCable(node.data.integratedWithCable ?? false);
     setIsVenueProvided(node.data.isVenueProvided ?? false);
@@ -210,7 +214,9 @@ export default function DeviceEditor() {
       ...(poeBudgetW != null ? { poeBudgetW } : {}),
       ...(voltage ? { voltage } : {}),
       ...(unitCost != null ? { unitCost } : {}),
-      ...(rackU != null ? { rackU } : {}),
+      ...(rackHeightU != null ? { rackHeightU } : {}),
+      ...(rackDepthMm != null ? { rackDepthMm } : {}),
+      ...(weight != null ? { weight } : {}),
       ...(isCableAccessory ? { isCableAccessory: true } : {}),
       ...(integratedWithCable ? { integratedWithCable: true } : {}),
       ...(isVenueProvided ? { isVenueProvided: true } : {}),
@@ -221,7 +227,7 @@ export default function DeviceEditor() {
     };
     updateDevice(editingNodeId, data);
     close();
-  }, [editingNodeId, ports, label, hostname, deviceType, color, headerColor, node, updateDevice, close, showAllPorts, hiddenPorts, dhcpServer, powerDrawW, powerCapacityW, voltage, poeBudgetW, unitCost, rackU, rackUCustom, isCableAccessory, integratedWithCable, isVenueProvided, adapterVisibility, auxiliaryData]);
+  }, [editingNodeId, ports, label, hostname, deviceType, color, headerColor, node, updateDevice, close, showAllPorts, hiddenPorts, dhcpServer, powerDrawW, powerCapacityW, voltage, poeBudgetW, unitCost, rackHeightU, rackHeightUCustom, rackDepthMm, weight, isCableAccessory, integratedWithCable, isVenueProvided, adapterVisibility, auxiliaryData]);
 
   // Ctrl+Enter anywhere in the editor → Apply & Close
   const onCtrlEnter = useCallback((e: React.KeyboardEvent) => {
@@ -673,40 +679,9 @@ export default function DeviceEditor() {
             setHiddenPorts={setHiddenPorts}
           />
 
-          {/* Hostname + Rack U */}
+          {/* Hostname */}
           <div className="flex items-center gap-2 mt-2">
-            <span className="text-[10px] text-[var(--color-text-muted)] shrink-0">Rack U:</span>
-            <select
-              className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs outline-none focus:border-blue-500"
-              value={rackUCustom ? "custom" : (rackU != null ? String(rackU) : "")}
-              onChange={(e) => {
-                const val = e.target.value;
-                if (val === "") { setRackUCustom(false); setRackU(undefined); }
-                else if (val === "custom") { setRackUCustom(true); setRackU(undefined); }
-                else { setRackUCustom(false); setRackU(Number(val)); }
-              }}
-            >
-              <option value="">—</option>
-              {([0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const).map((u) => (
-                <option key={u} value={u}>
-                  {u === 0.25 ? "¼U" : u === 0.5 ? "½U" : `${u}U`}
-                </option>
-              ))}
-              <option value="custom">Custom</option>
-            </select>
-            {rackUCustom && (
-              <input
-                type="number"
-                className="w-16 bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs outline-none focus:border-blue-500"
-                value={rackU ?? ""}
-                onChange={(e) => setRackU(e.target.value ? Number(e.target.value) : undefined)}
-                placeholder="e.g. 14"
-                min={1}
-                step={1}
-                onKeyDown={(e) => e.stopPropagation()}
-              />
-            )}
-            <span className="text-[10px] text-[var(--color-text-muted)] shrink-0 ml-2">Hostname:</span>
+            <span className="text-[10px] text-[var(--color-text-muted)] shrink-0">Hostname:</span>
             <input
               className="flex-1 bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-0.5 text-xs outline-none focus:border-blue-500"
               value={hostname}
@@ -715,6 +690,81 @@ export default function DeviceEditor() {
               onKeyDown={(e) => e.stopPropagation()}
             />
           </div>
+
+          {/* Rack Properties */}
+          <details className="text-xs">
+            <summary className="cursor-pointer text-[var(--color-text-secondary)] hover:text-[var(--color-text)] select-none py-1">
+              Rack Properties
+            </summary>
+            <div className="pt-1 pl-2 grid grid-cols-3 gap-3">
+              <div>
+                <label className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-0.5">
+                  Height
+                </label>
+                <div className="flex items-center gap-1">
+                  <select
+                    className="flex-1 bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-1 text-xs outline-none focus:border-blue-500"
+                    value={rackHeightUCustom ? "custom" : (rackHeightU != null ? String(rackHeightU) : "")}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      if (val === "") { setRackHeightUCustom(false); setRackHeightU(undefined); }
+                      else if (val === "custom") { setRackHeightUCustom(true); setRackHeightU(undefined); }
+                      else { setRackHeightUCustom(false); setRackHeightU(Number(val)); }
+                    }}
+                  >
+                    <option value="">—</option>
+                    {([0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const).map((u) => (
+                      <option key={u} value={u}>
+                        {u === 0.25 ? "¼U" : u === 0.5 ? "½U" : `${u}U`}
+                      </option>
+                    ))}
+                    <option value="custom">Custom</option>
+                  </select>
+                </div>
+                {rackHeightUCustom && (
+                  <input
+                    type="number"
+                    className="mt-1 w-full bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-1 text-xs outline-none focus:border-blue-500"
+                    value={rackHeightU ?? ""}
+                    onChange={(e) => setRackHeightU(e.target.value ? Number(e.target.value) : undefined)}
+                    placeholder="e.g. 14"
+                    min={1}
+                    step={1}
+                    onKeyDown={(e) => e.stopPropagation()}
+                  />
+                )}
+              </div>
+              <div>
+                <label className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-0.5">
+                  Depth (mm)
+                </label>
+                <input
+                  type="number"
+                  className="w-full bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-1 text-xs outline-none focus:border-blue-500"
+                  value={rackDepthMm ?? ""}
+                  onChange={(e) => setRackDepthMm(e.target.value ? Number(e.target.value) : undefined)}
+                  placeholder="e.g. 482"
+                  min={1}
+                  onKeyDown={(e) => e.stopPropagation()}
+                />
+              </div>
+              <div>
+                <label className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-0.5">
+                  Weight (kg)
+                </label>
+                <input
+                  type="number"
+                  className="w-full bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-1.5 py-1 text-xs outline-none focus:border-blue-500"
+                  value={weight ?? ""}
+                  onChange={(e) => setWeight(e.target.value ? Number(e.target.value) : undefined)}
+                  placeholder="e.g. 2.5"
+                  min={0}
+                  step={0.1}
+                  onKeyDown={(e) => e.stopPropagation()}
+                />
+              </div>
+            </div>
+          </details>
 
           {ports.some((p) => p.connectorType === "rj45" || p.connectorType === "ethercon") && (
             <>

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,7 +202,11 @@ export interface DeviceData {
   unitCost?: number;
   isVenueProvided?: boolean;
   /** Rack unit height (e.g. 1 = 1U, 2 = 2U) — reserved for future rack management */
-  rackU?: number;
+  rackHeightU?: number;
+  /** Rack depth in millimeters — reserved for future rack management */
+  rackDepthMm?: number;
+  /** Device weight in kilograms — reserved for future rack management */
+  weight?: number;
   /** Adapter visibility override — only meaningful for deviceType "adapter" */
   adapterVisibility?: "default" | "force-show" | "force-hide";
   /** User-customizable auxiliary data lines (up to 5) displayed at bottom of device node */

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,6 +201,8 @@ export interface DeviceData {
   /** Unit cost in dollars (optional, for BOM/quoting) */
   unitCost?: number;
   isVenueProvided?: boolean;
+  /** Rack unit height (e.g. 1 = 1U, 2 = 2U) — reserved for future rack management */
+  rackU?: number;
   /** Adapter visibility override — only meaningful for deviceType "adapter" */
   adapterVisibility?: "default" | "force-show" | "force-hide";
   /** User-customizable auxiliary data lines (up to 5) displayed at bottom of device node */

--- a/src/types.ts
+++ b/src/types.ts
@@ -308,6 +308,9 @@ export interface DeviceTemplate {
   isVenueProvided?: boolean;     // Venue-owned gear — excluded from pack list
   poeBudgetW?: number;           // PoE budget in watts (switches only)
   unitCost?: number;             // MSRP / default unit cost in dollars
+  rackHeightU?: number;          // Rack unit height — reserved for future rack management
+  rackDepthMm?: number;          // Rack depth in millimeters — reserved for future rack management
+  weight?: number;               // Device weight in kilograms — reserved for future rack management
 }
 
 export interface CustomTemplateGroup {


### PR DESCRIPTION
## Add rack properties to equipment nodes and device submission form

This PR adds rackHeightU, rackDepthMm, and weight fields as groundwork for a future rack building/management feature. Fields are stored on the node/template but have no functional effect yet.

I mainly wanted to start trying to capture as much rack information on device submissions as possible so whenever racking workflows are realized the backlog of devices lacking rack information is limited.

This work was cross-referenced against [@duremovich's rack-builder fork](https://github.com/duremovich/EasySchematic/tree/rack-builder) to align field names and data model so a future merges will hopefully have minimal conflicts.

##Changes

- src/types.ts

Added rackHeightU?, rackDepthMm?, and weight? to both DeviceData and DeviceTemplate

- src/components/DeviceEditor.tsx

New collapsible Rack Properties section in the device editor with:
Height — number input (1-20)
Depth (mm) — number input
Weight (kg) — number input (0.1 step)

- devices/src/components/DeviceForm.tsx

Added Rack Height (U), Rack Depth (mm), and Weight (kg) fields to the community device submission form, after the existing power fields, with spec-sheet helper text
Wired through DeviceFormData interface, both load paths (template edit + draft), and submit payload

##Notes
All fields are optional; existing devices and templates are unaffected
Field names match the rack-builder fork to ease future integration
No exports, BOM, or rendering logic is affected