### PR TITLE
Change text color of signal types

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -158,7 +158,7 @@ export default function LandingPage() {
             {signalSamples.map((s) => (
               <span
                 key={s.name}
-                className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-slate-50 border border-slate-200 text-sm font-medium text-gray-700"
+                className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-slate-50 border border-slate-200 text-sm font-medium text-black"
               >
                 <span
                   className="w-3 h-3 rounded-full shrink-0"


### PR DESCRIPTION
## Description

Changes the text color of signal types to improve readability.

## Testing

Was previously `text-gray-700` making it really hard to read and even more faint than the `text-gray-500` of the "+23 more". I tested changing it to `text-gray-500` but it still felt weird having the same visual "weight" as the "+23 more". `text-black` felt the best and most readable, while preserving the visual hierarchy. If something different is desired let me know!

## Screenshots
Before
<img width="1094" height="190" alt="Screenshot 2026-04-12 at 3 45 15 PM" src="https://github.com/user-attachments/assets/b9c00e7c-c593-4e09-af98-0bc5abc6e774" />

After
<img width="1186" height="196" alt="Screenshot 2026-04-12 at 3 50 35 PM" src="https://github.com/user-attachments/assets/747ee405-2792-4907-8215-02d4fd1b2bee" />
