### PR TITLE
Investigate issue:146

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "easyschematic",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "easyschematic",
-      "version": "0.29.0",
+      "version": "0.30.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {

--- a/src/__tests__/roomDistance.test.ts
+++ b/src/__tests__/roomDistance.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import {
+  pairKey,
+  getTopLevelRoomId,
+  isTopLevelRoom,
+  listTopLevelRooms,
+  getRoomDistance,
+  computeCableLength,
+  formatLength,
+} from "../roomDistance";
+import type { RoomData, SchematicNode } from "../types";
+
+function makeRoom(id: string, label: string, parentId?: string): SchematicNode {
+  return {
+    id,
+    type: "room",
+    position: { x: 0, y: 0 },
+    data: { label } as RoomData,
+    ...(parentId ? { parentId } : {}),
+  } as SchematicNode;
+}
+
+function makeDevice(id: string, parentId?: string): SchematicNode {
+  return {
+    id,
+    type: "device",
+    position: { x: 0, y: 0 },
+    data: { label: "dev" } as unknown as RoomData,
+    ...(parentId ? { parentId } : {}),
+  } as SchematicNode;
+}
+
+describe("pairKey", () => {
+  it("is symmetric regardless of argument order", () => {
+    expect(pairKey("a", "b")).toBe(pairKey("b", "a"));
+  });
+
+  it("produces a sorted 'a|b' key", () => {
+    expect(pairKey("b", "a")).toBe("a|b");
+    expect(pairKey("room-1", "room-2")).toBe("room-1|room-2");
+  });
+
+  it("distinguishes distinct pairs", () => {
+    expect(pairKey("a", "b")).not.toBe(pairKey("a", "c"));
+  });
+});
+
+describe("getTopLevelRoomId", () => {
+  it("returns the id itself for a top-level room", () => {
+    const nodes = [makeRoom("r1", "Room 1")];
+    expect(getTopLevelRoomId("r1", nodes)).toBe("r1");
+  });
+
+  it("walks up a 3-deep nesting chain to the top-level ancestor", () => {
+    const nodes = [
+      makeRoom("top", "Top"),
+      makeRoom("mid", "Mid", "top"),
+      makeRoom("leaf", "Leaf", "mid"),
+    ];
+    expect(getTopLevelRoomId("leaf", nodes)).toBe("top");
+    expect(getTopLevelRoomId("mid", nodes)).toBe("top");
+    expect(getTopLevelRoomId("top", nodes)).toBe("top");
+  });
+
+  it("returns undefined when roomId is missing or not a room", () => {
+    const nodes = [makeRoom("r1", "Room 1"), makeDevice("d1", "r1")];
+    expect(getTopLevelRoomId(undefined, nodes)).toBeUndefined();
+    expect(getTopLevelRoomId("does-not-exist", nodes)).toBeUndefined();
+    expect(getTopLevelRoomId("d1", nodes)).toBeUndefined();
+  });
+
+  it("handles a cyclic parent chain without infinite looping", () => {
+    const nodes = [
+      makeRoom("a", "A", "b"),
+      makeRoom("b", "B", "a"),
+    ];
+    const result = getTopLevelRoomId("a", nodes);
+    expect(result === "a" || result === "b").toBe(true);
+  });
+});
+
+describe("isTopLevelRoom", () => {
+  it("returns true for a room with no parent", () => {
+    const nodes = [makeRoom("r1", "Room 1")];
+    expect(isTopLevelRoom("r1", nodes)).toBe(true);
+  });
+
+  it("returns false for a nested room", () => {
+    const nodes = [makeRoom("top", "Top"), makeRoom("leaf", "Leaf", "top")];
+    expect(isTopLevelRoom("leaf", nodes)).toBe(false);
+  });
+
+  it("returns false for a non-room id", () => {
+    const nodes = [makeRoom("r1", "Room 1"), makeDevice("d1", "r1")];
+    expect(isTopLevelRoom("d1", nodes)).toBe(false);
+    expect(isTopLevelRoom("missing", nodes)).toBe(false);
+  });
+});
+
+describe("listTopLevelRooms", () => {
+  it("returns only top-level rooms with their labels", () => {
+    const nodes = [
+      makeRoom("a", "Room A"),
+      makeRoom("b", "Room B"),
+      makeRoom("a-child", "Child", "a"),
+      makeDevice("d1"),
+    ];
+    const result = listTopLevelRooms(nodes);
+    expect(result).toEqual([
+      { id: "a", label: "Room A" },
+      { id: "b", label: "Room B" },
+    ]);
+  });
+});
+
+describe("getRoomDistance", () => {
+  const nodes = [
+    makeRoom("a", "A"),
+    makeRoom("b", "B"),
+    makeRoom("a-leaf", "A Leaf", "a"),
+  ];
+  const file = { roomDistances: { [pairKey("a", "b")]: 50 } };
+
+  it("resolves a direct top-level pair", () => {
+    expect(getRoomDistance("a", "b", file, nodes)).toBe(50);
+    expect(getRoomDistance("b", "a", file, nodes)).toBe(50);
+  });
+
+  it("resolves via a nested room's top-level ancestor", () => {
+    expect(getRoomDistance("a-leaf", "b", file, nodes)).toBe(50);
+  });
+
+  it("returns undefined when both rooms share a top-level ancestor", () => {
+    expect(getRoomDistance("a", "a-leaf", file, nodes)).toBeUndefined();
+  });
+
+  it("returns undefined when no entry is stored", () => {
+    expect(getRoomDistance("a", "b", { roomDistances: {} }, nodes)).toBeUndefined();
+    expect(getRoomDistance("a", "b", {}, nodes)).toBeUndefined();
+  });
+});
+
+describe("computeCableLength", () => {
+  it("applies percent slack and fixed addition", () => {
+    expect(computeCableLength(100, { unit: "m", slackPercent: 15, slackFixed: 2 })).toBeCloseTo(117);
+  });
+
+  it("returns the raw distance when slack is zero", () => {
+    expect(computeCableLength(42, { unit: "m", slackPercent: 0, slackFixed: 0 })).toBe(42);
+  });
+
+  it("treats non-finite slack values as zero", () => {
+    expect(
+      computeCableLength(10, { unit: "m", slackPercent: Number.NaN, slackFixed: Number.NaN }),
+    ).toBe(10);
+  });
+
+  it("clamps negative results to zero", () => {
+    expect(computeCableLength(1, { unit: "m", slackPercent: 0, slackFixed: -10 })).toBe(0);
+  });
+});
+
+describe("formatLength", () => {
+  it("formats with one decimal place and unit suffix", () => {
+    expect(formatLength(117, "m")).toBe("117.0 m");
+    expect(formatLength(42.5, "ft")).toBe("42.5 ft");
+  });
+});

--- a/src/cableSchedule.ts
+++ b/src/cableSchedule.ts
@@ -2,6 +2,7 @@ import type {
   SchematicNode,
   ConnectionEdge,
   SignalType,
+  DistanceSettings,
 } from "./types";
 import { SIGNAL_LABELS, CONNECTOR_LABELS } from "./types";
 import { getCableType } from "./cableTypes";
@@ -10,6 +11,12 @@ import { transformLabelNow } from "./labelCaseUtils";
 import type { ReportLayout } from "./reportLayout";
 import type { ReportTableData } from "./reportPdf";
 import type { DeviceData } from "./types";
+import { computeCableLength, formatLength, getRoomDistance } from "./roomDistance";
+
+export interface CableScheduleDistanceContext {
+  roomDistances?: Record<string, number>;
+  distanceSettings?: DistanceSettings;
+}
 
 export interface CableScheduleRow {
   edgeId: string;
@@ -23,6 +30,8 @@ export interface CableScheduleRow {
   cableType: string;
   signalType: string;
   cableLength: string;
+  /** Estimated cable length derived from room-to-room distance + slack (#146). */
+  computedLength?: string;
   sourceRoom: string;
   targetRoom: string;
   multicableLabel: string;
@@ -99,6 +108,7 @@ export function computeCableSchedule(
   nodes: SchematicNode[],
   edges: ConnectionEdge[],
   namingScheme: "sequential" | "type-prefix" = "sequential",
+  distanceContext?: CableScheduleDistanceContext,
 ): CableScheduleRow[] {
   const connections = edges
     .filter((e) => e.data?.signalType && !e.data?.directAttach)
@@ -108,6 +118,12 @@ export function computeCableSchedule(
       const signalType = e.data!.signalType as SignalType;
       const srcPort = resolvePort(srcNode, e.sourceHandle);
       const tgtPort = resolvePort(tgtNode, e.targetHandle);
+      const computedLength = computeRowEstimatedLength(
+        srcNode?.parentId,
+        tgtNode?.parentId,
+        nodes,
+        distanceContext,
+      );
 
       const sourceDevice = srcNode?.type === "device"
         ? transformLabelNow((srcNode.data as DeviceData).label)
@@ -142,6 +158,7 @@ export function computeCableSchedule(
         signalType: SIGNAL_LABELS[signalType],
         sourceRoom,
         targetRoom,
+        computedLength,
       };
     });
 
@@ -166,6 +183,7 @@ export function computeCableSchedule(
         cableType: c.cableType,
         signalType: c.signalType,
         cableLength: c.storedCableLength,
+        computedLength: c.computedLength,
         sourceRoom: c.sourceRoom,
         targetRoom: c.targetRoom,
         multicableLabel: c.multicableLabel,
@@ -185,10 +203,23 @@ export function computeCableSchedule(
     cableType: c.cableType,
     signalType: c.signalType,
     cableLength: c.storedCableLength,
+    computedLength: c.computedLength,
     sourceRoom: c.sourceRoom,
     targetRoom: c.targetRoom,
     multicableLabel: c.multicableLabel,
   }));
+}
+
+function computeRowEstimatedLength(
+  sourceParentId: string | undefined,
+  targetParentId: string | undefined,
+  nodes: SchematicNode[],
+  ctx: CableScheduleDistanceContext | undefined,
+): string | undefined {
+  if (!ctx?.roomDistances || !ctx.distanceSettings) return undefined;
+  const dist = getRoomDistance(sourceParentId, targetParentId, { roomDistances: ctx.roomDistances }, nodes);
+  if (dist === undefined) return undefined;
+  return formatLength(computeCableLength(dist, ctx.distanceSettings), ctx.distanceSettings.unit);
 }
 
 export function exportCableScheduleCsv(
@@ -204,14 +235,14 @@ export function exportCableScheduleCsv(
   lines.push(csvRow([
     "Cable ID", "Source", "Src Port", "Src Conn",
     "Target", "Tgt Port", "Tgt Conn",
-    "Cable Type", "Signal", "Length",
+    "Cable Type", "Signal", "Length", "Est. Length",
     "Src Room", "Tgt Room", "Snake",
   ]));
   for (const r of rows) {
     lines.push(csvRow([
       r.cableId, r.sourceDevice, r.sourcePort, r.sourceConnector,
       r.targetDevice, r.targetPort, r.targetConnector,
-      r.cableType, r.signalType, r.cableLength,
+      r.cableType, r.signalType, r.cableLength, r.computedLength ?? "",
       r.sourceRoom, r.targetRoom, r.multicableLabel,
     ]));
   }
@@ -242,6 +273,7 @@ export function getCableScheduleTableData(
     cableType: r.cableType,
     signalType: r.signalType,
     cableLength: r.cableLength,
+    computedLength: r.computedLength ?? "",
     sourceRoom: r.sourceRoom,
     targetRoom: r.targetRoom,
     multicableLabel: r.multicableLabel,

--- a/src/cableSchedule.ts
+++ b/src/cableSchedule.ts
@@ -4,7 +4,7 @@ import type {
   SignalType,
   DistanceSettings,
 } from "./types";
-import { SIGNAL_LABELS, CONNECTOR_LABELS } from "./types";
+import { SIGNAL_LABELS, CONNECTOR_LABELS, DEFAULT_DISTANCE_SETTINGS } from "./types";
 import { getCableType } from "./cableTypes";
 import { resolvePort, resolvePortLabel, getRoomLabel, escapeCsv, csvRow, groupBy } from "./packList";
 import { transformLabelNow } from "./labelCaseUtils";
@@ -217,10 +217,11 @@ function computeRowEstimatedLength(
   nodes: SchematicNode[],
   ctx: CableScheduleDistanceContext | undefined,
 ): string | undefined {
-  if (!ctx?.roomDistances || !ctx.distanceSettings) return undefined;
+  if (!ctx?.roomDistances) return undefined;
   const dist = getRoomDistance(sourceParentId, targetParentId, { roomDistances: ctx.roomDistances }, nodes);
   if (dist === undefined) return undefined;
-  return formatLength(computeCableLength(dist, ctx.distanceSettings), ctx.distanceSettings.unit);
+  const settings = ctx.distanceSettings ?? DEFAULT_DISTANCE_SETTINGS;
+  return formatLength(computeCableLength(dist, settings), settings.unit);
 }
 
 export function exportCableScheduleCsv(

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -12,6 +12,7 @@ import ReportsDialog, { type ReportsTab } from "./ReportsDialog";
 import TitleBlockDialog from "./TitleBlockDialog";
 import AboutDialog from "./AboutDialog";
 import PreferencesDialog from "./PreferencesDialog";
+import RoomDistancesDialog from "./RoomDistancesDialog";
 import AlignmentMenu from "./AlignmentMenu";
 import UserMenuButton from "./UserMenuButton";
 import SchematicBrowser from "./SchematicBrowser";
@@ -141,6 +142,7 @@ export default function MenuBar() {
   const [showTitleBlockDialog, setShowTitleBlockDialog] = useState(false);
   const [showAboutDialog, setShowAboutDialog] = useState(false);
   const [showPreferences, setShowPreferences] = useState(false);
+  const [showRoomDistances, setShowRoomDistances] = useState(false);
   const [showCsvImport, setShowCsvImport] = useState(false);
   const [showSchematicBrowser, setShowSchematicBrowser] = useState(false);
   const [showCloudLogin, setShowCloudLogin] = useState(false);
@@ -589,6 +591,8 @@ export default function MenuBar() {
       { type: "item", label: "Pack List...", onClick: () => setReportsTab("packList") },
       { type: "item", label: "Network Report...", onClick: () => setReportsTab("network") },
       { type: "item", label: "Power Report...", onClick: () => setReportsTab("power") },
+      { type: "separator" },
+      { type: "item", label: "Room Distances...", onClick: () => setShowRoomDistances(true) },
     ],
     Help: [
       {
@@ -962,6 +966,9 @@ export default function MenuBar() {
       )}
       {showPreferences && (
         <PreferencesDialog onClose={() => setShowPreferences(false)} />
+      )}
+      {showRoomDistances && (
+        <RoomDistancesDialog onClose={() => setShowRoomDistances(false)} />
       )}
       {showCsvImport && (
         <CsvImportWizard onClose={() => setShowCsvImport(false)} />

--- a/src/components/ReportsDialog.tsx
+++ b/src/components/ReportsDialog.tsx
@@ -81,8 +81,11 @@ function ReportsDialog({ initialTab, onClose }: ReportsDialogProps) {
     } else if (tab === "devices") {
       exportDevicesCsv(nodes, ownedGear, schematicName);
     } else if (tab === "cableSchedule") {
-      const cableNamingScheme = useSchematicStore.getState().cableNamingScheme;
-      const rows = computeCableSchedule(nodes, edges, cableNamingScheme);
+      const s = useSchematicStore.getState();
+      const rows = computeCableSchedule(nodes, edges, s.cableNamingScheme, {
+        roomDistances: s.roomDistances,
+        distanceSettings: s.distanceSettings,
+      });
       exportCableScheduleCsv(rows, schematicName);
     } else if (tab === "patchPanel") {
       const cableNamingScheme = useSchematicStore.getState().cableNamingScheme;
@@ -237,9 +240,16 @@ function ReportsDialog({ initialTab, onClose }: ReportsDialogProps) {
           reportKey={CABLE_SCHEDULE_LAYOUT_KEY}
           defaultLayout={cableScheduleDefaultLayout}
           titleBlock={titleBlock}
-          getTableData={(layout) =>
-            getCableScheduleTableData(computeCableSchedule(nodes, edges, useSchematicStore.getState().cableNamingScheme), layout)
-          }
+          getTableData={(layout) => {
+            const s = useSchematicStore.getState();
+            return getCableScheduleTableData(
+              computeCableSchedule(nodes, edges, s.cableNamingScheme, {
+                roomDistances: s.roomDistances,
+                distanceSettings: s.distanceSettings,
+              }),
+              layout,
+            );
+          }}
           onClose={() => setShowCableSchedulePreview(false)}
           filename={`${schematicName.replace(/[^a-zA-Z0-9-_ ]/g, "")} - Cable Schedule.pdf`}
         />
@@ -1393,7 +1403,7 @@ const DeviceRow = memo(function DeviceRow({
 
 // ─── Cable Schedule Tab ────────────────────────────────────────
 
-type CableSortKey = "cableId" | "sourceDevice" | "sourcePort" | "sourceConnector" | "targetDevice" | "targetPort" | "targetConnector" | "cableType" | "signalType" | "cableLength" | "sourceRoom" | "targetRoom" | "multicableLabel";
+type CableSortKey = "cableId" | "sourceDevice" | "sourcePort" | "sourceConnector" | "targetDevice" | "targetPort" | "targetConnector" | "cableType" | "signalType" | "cableLength" | "computedLength" | "sourceRoom" | "targetRoom" | "multicableLabel";
 type CableGroupBy = "" | "sourceRoom" | "signalType" | "cableType" | "multicableLabel";
 
 const cableScheduleColumns: SpreadsheetColumn<CableScheduleRow>[] = [
@@ -1414,7 +1424,12 @@ function CableScheduleTabInline() {
   const [groupByKey, setGroupByKey] = useState<CableGroupBy>("");
 
   const cableNamingScheme = useSchematicStore((s) => s.cableNamingScheme);
-  const rows = useMemo(() => computeCableSchedule(nodes, edges, cableNamingScheme), [nodes, edges, cableNamingScheme]);
+  const roomDistances = useSchematicStore((s) => s.roomDistances);
+  const distanceSettings = useSchematicStore((s) => s.distanceSettings);
+  const rows = useMemo(
+    () => computeCableSchedule(nodes, edges, cableNamingScheme, { roomDistances, distanceSettings }),
+    [nodes, edges, cableNamingScheme, roomDistances, distanceSettings],
+  );
 
   const filtered = useMemo(() => {
     const q = filter.toLowerCase();
@@ -1431,6 +1446,7 @@ function CableScheduleTabInline() {
         r.cableType.toLowerCase().includes(q) ||
         r.signalType.toLowerCase().includes(q) ||
         r.cableLength.toLowerCase().includes(q) ||
+        (r.computedLength ?? "").toLowerCase().includes(q) ||
         r.sourceRoom.toLowerCase().includes(q) ||
         r.targetRoom.toLowerCase().includes(q) ||
         r.multicableLabel.toLowerCase().includes(q),
@@ -1440,7 +1456,7 @@ function CableScheduleTabInline() {
   const sorted = useMemo(() => {
     const copy = [...filtered];
     copy.sort((a, b) => {
-      const cmp = a[sortKey].localeCompare(b[sortKey]);
+      const cmp = (a[sortKey] ?? "").localeCompare(b[sortKey] ?? "");
       return sortAsc ? cmp : -cmp;
     });
     return copy;
@@ -1614,6 +1630,7 @@ function CableScheduleTabInline() {
               <th className={thClass} onClick={() => toggleSort("cableType")}>Cable Type{sortArrow("cableType")}</th>
               <th className={thClass} onClick={() => toggleSort("signalType")}>Signal{sortArrow("signalType")}</th>
               <th className={thClass} onClick={() => toggleSort("cableLength")}>Length{sortArrow("cableLength")}</th>
+              <th className={thClass} onClick={() => toggleSort("computedLength")} title="Estimated length from room-to-room distance + slack">Est. Length{sortArrow("computedLength")}</th>
               <th className={thClass} onClick={() => toggleSort("sourceRoom")}>Src Room{sortArrow("sourceRoom")}</th>
               <th className={thClass} onClick={() => toggleSort("targetRoom")}>Tgt Room{sortArrow("targetRoom")}</th>
               <th className={thClass} onClick={() => toggleSort("multicableLabel")}>Snake{sortArrow("multicableLabel")}</th>
@@ -1737,6 +1754,7 @@ const CableScheduleRow_ = memo(function CableScheduleRow_({
       <td className={tdClass}>{row.cableType}</td>
       <td className={tdClass}>{row.signalType}</td>
       <EditableCell spreadsheet={spreadsheet} rowIndex={rowIndex} columnId="cableLength" value={row.cableLength} />
+      <td className={`${tdClass} text-[var(--color-text-muted)]`}>{row.computedLength ?? ""}</td>
       <td className={tdClass}>{row.sourceRoom}</td>
       <td className={tdClass}>{row.targetRoom}</td>
       <td className={tdClass}>{row.multicableLabel}</td>
@@ -1766,7 +1784,7 @@ function renderGroupedCableSchedule(
     elements.push(
       <tr key={`h-${group}`}>
         <td
-          colSpan={14}
+          colSpan={15}
           className="pt-3 pb-1 px-2 text-xs font-semibold text-[var(--color-text-heading)] border-b border-[var(--color-border)]"
         >
           {group}

--- a/src/components/RoomDistancesDialog.tsx
+++ b/src/components/RoomDistancesDialog.tsx
@@ -1,0 +1,151 @@
+import { useMemo } from "react";
+import { useSchematicStore } from "../store";
+import { DEFAULT_DISTANCE_SETTINGS } from "../types";
+import { listTopLevelRooms, pairKey } from "../roomDistance";
+
+interface RoomDistancesDialogProps {
+  onClose: () => void;
+}
+
+export default function RoomDistancesDialog({ onClose }: RoomDistancesDialogProps) {
+  const nodes = useSchematicStore((s) => s.nodes);
+  const roomDistances = useSchematicStore((s) => s.roomDistances);
+  const distanceSettings = useSchematicStore((s) => s.distanceSettings);
+  const setRoomDistance = useSchematicStore((s) => s.setRoomDistance);
+  const setDistanceSettings = useSchematicStore((s) => s.setDistanceSettings);
+
+  const settings = distanceSettings ?? DEFAULT_DISTANCE_SETTINGS;
+  const rooms = useMemo(() => listTopLevelRooms(nodes), [nodes]);
+
+  const pairs = useMemo(() => {
+    const out: Array<{ a: { id: string; label: string }; b: { id: string; label: string }; key: string }> = [];
+    for (let i = 0; i < rooms.length; i++) {
+      for (let j = i + 1; j < rooms.length; j++) {
+        out.push({ a: rooms[i], b: rooms[j], key: pairKey(rooms[i].id, rooms[j].id) });
+      }
+    }
+    return out;
+  }, [rooms]);
+
+  const labelClass = "block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-1";
+  const inputClass =
+    "bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2 py-1 text-xs text-[var(--color-text-heading)] outline-none focus:border-blue-500";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="bg-white border border-[var(--color-border)] rounded-lg shadow-2xl w-[520px] max-h-[80vh] flex flex-col">
+        <div className="px-4 py-3 border-b border-[var(--color-border)] flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-[var(--color-text-heading)]">Room Distances</h2>
+          <button
+            onClick={onClose}
+            className="text-[var(--color-text-muted)] hover:text-[var(--color-text-heading)] text-lg leading-none cursor-pointer"
+          >
+            &times;
+          </button>
+        </div>
+
+        <div className="p-4 space-y-4 overflow-y-auto">
+          <p className="text-[11px] text-[var(--color-text-muted)] leading-relaxed">
+            Set the physical distance between top-level rooms. Estimated cable length
+            for each connection is shown in the Cable Schedule alongside any manual
+            length you&rsquo;ve entered. Devices in nested subrooms inherit the distance
+            of their top-level room.
+          </p>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <label className={labelClass}>Unit</label>
+              <div className="flex items-center gap-1">
+                {(["m", "ft"] as const).map((u) => (
+                  <button
+                    key={u}
+                    onClick={() => setDistanceSettings({ unit: u })}
+                    className={`px-3 py-1 text-xs rounded border cursor-pointer transition-colors ${
+                      settings.unit === u
+                        ? "bg-blue-50 border-blue-400 text-blue-700"
+                        : "bg-[var(--color-surface)] border-[var(--color-border)] text-[var(--color-text)] hover:text-[var(--color-text-heading)]"
+                    }`}
+                  >
+                    {u}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <label className={labelClass}>Slack %</label>
+              <input
+                type="number"
+                min={0}
+                step={1}
+                value={settings.slackPercent}
+                onChange={(e) => setDistanceSettings({ slackPercent: Number(e.target.value) })}
+                className={`${inputClass} w-24`}
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Slack +{settings.unit}</label>
+              <input
+                type="number"
+                min={0}
+                step={0.5}
+                value={settings.slackFixed}
+                onChange={(e) => setDistanceSettings({ slackFixed: Number(e.target.value) })}
+                className={`${inputClass} w-24`}
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+            </div>
+          </div>
+
+          <div className="pt-2 border-t border-[var(--color-border)]">
+            <div className={labelClass}>Room pairs ({settings.unit})</div>
+            {rooms.length < 2 ? (
+              <p className="text-xs text-[var(--color-text-muted)] mt-2">
+                Create at least two top-level rooms to define distances.
+              </p>
+            ) : (
+              <div className="space-y-1 mt-1 max-h-[50vh] overflow-y-auto pr-1">
+                {pairs.map(({ a, b, key }) => {
+                  const current = roomDistances?.[key];
+                  return (
+                    <div key={key} className="flex items-center justify-between gap-2 py-1">
+                      <span className="text-xs text-[var(--color-text)] flex-1 truncate">
+                        {a.label} <span className="text-[var(--color-text-muted)]">↔</span> {b.label}
+                      </span>
+                      <input
+                        type="number"
+                        min={0}
+                        step={0.5}
+                        value={current ?? ""}
+                        placeholder="—"
+                        onChange={(e) => {
+                          const raw = e.target.value;
+                          const value = raw === "" ? undefined : Number(raw);
+                          setRoomDistance(a.id, b.id, value);
+                        }}
+                        className={`${inputClass} w-24 text-right`}
+                        onKeyDown={(e) => e.stopPropagation()}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="px-4 py-3 border-t border-[var(--color-border)] flex items-center justify-end">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs rounded bg-blue-600 text-white hover:bg-blue-500 transition-colors cursor-pointer"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RoomEditor.tsx
+++ b/src/components/RoomEditor.tsx
@@ -1,6 +1,8 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useSchematicStore } from "../store";
-import type { RoomData, RoomNode } from "../types";
+import { DEFAULT_DISTANCE_SETTINGS } from "../types";
+import type { DistanceSettings, RoomData, RoomNode, SchematicNode } from "../types";
+import { getTopLevelRoomId, isTopLevelRoom, listTopLevelRooms, pairKey } from "../roomDistance";
 
 const BORDER_STYLES: { value: RoomData["borderStyle"]; label: string }[] = [
   { value: "dashed", label: "Dashed" },
@@ -21,6 +23,9 @@ export default function RoomEditor() {
   const updateRoom = useSchematicStore((s) => s.updateRoom);
   const toggleRoomLock = useSchematicStore((s) => s.toggleRoomLock);
   const setEditingNodeId = useSchematicStore((s) => s.setEditingNodeId);
+  const roomDistances = useSchematicStore((s) => s.roomDistances);
+  const distanceSettings = useSchematicStore((s) => s.distanceSettings);
+  const setRoomDistance = useSchematicStore((s) => s.setRoomDistance);
 
   const node = nodes.find((n) => n.id === editingNodeId && n.type === "room") as RoomNode | undefined;
 
@@ -137,6 +142,15 @@ export default function RoomEditor() {
             </div>
           )}
 
+          {/* Distances to other rooms (#146) */}
+          <RoomDistancesSection
+            roomId={node.id}
+            nodes={nodes}
+            roomDistances={roomDistances}
+            unit={(distanceSettings ?? DEFAULT_DISTANCE_SETTINGS).unit}
+            setRoomDistance={setRoomDistance}
+          />
+
           {/* Label Size */}
           <div>
             <label className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-1">
@@ -245,6 +259,95 @@ export default function RoomEditor() {
             Apply
           </button>
         </div>
+      </div>
+    </div>
+  );
+}
+
+function RoomDistancesSection({
+  roomId,
+  nodes,
+  roomDistances,
+  unit,
+  setRoomDistance,
+}: {
+  roomId: string;
+  nodes: SchematicNode[];
+  roomDistances: Record<string, number> | undefined;
+  unit: DistanceSettings["unit"];
+  setRoomDistance: (a: string, b: string, distance: number | undefined) => void;
+}) {
+  const topLevel = isTopLevelRoom(roomId, nodes);
+  const ancestorId = useMemo(() => getTopLevelRoomId(roomId, nodes), [roomId, nodes]);
+  const others = useMemo(
+    () => listTopLevelRooms(nodes).filter((r) => r.id !== (topLevel ? roomId : ancestorId)),
+    [nodes, roomId, topLevel, ancestorId],
+  );
+
+  if (!topLevel) {
+    const ancestorLabel =
+      ancestorId
+        ? (nodes.find((n) => n.id === ancestorId)?.data as RoomData | undefined)?.label ?? "parent room"
+        : "parent room";
+    return (
+      <div>
+        <label className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-1">
+          Distances
+        </label>
+        <p className="text-[11px] text-[var(--color-text-muted)]">
+          Inherited from the top-level room ({ancestorLabel}). Edit distances on that room or in Reports &rsaquo; Room Distances.
+        </p>
+      </div>
+    );
+  }
+
+  if (others.length === 0) {
+    return (
+      <div>
+        <label className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-1">
+          Distances
+        </label>
+        <p className="text-[11px] text-[var(--color-text-muted)]">
+          Add another top-level room to set a distance.
+        </p>
+      </div>
+    );
+  }
+
+  const inputClass =
+    "bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2 py-1 text-xs text-[var(--color-text-heading)] outline-none focus:border-blue-500 w-20 text-right";
+
+  return (
+    <div>
+      <label className="block text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-1">
+        Distances ({unit})
+      </label>
+      <div className="space-y-1 max-h-[160px] overflow-y-auto pr-1">
+        {others.map((r) => {
+          const key = pairKey(roomId, r.id);
+          const current = roomDistances?.[key];
+          return (
+            <div key={r.id} className="flex items-center justify-between gap-2 py-0.5">
+              <span className="text-xs text-[var(--color-text)] flex-1 truncate" title={r.label}>
+                {r.label}
+              </span>
+              <input
+                type="number"
+                min={0}
+                step={0.5}
+                value={current ?? ""}
+                placeholder="—"
+                onChange={(e) => {
+                  const raw = e.target.value;
+                  const value = raw === "" ? undefined : Number(raw);
+                  setRoomDistance(roomId, r.id, value);
+                }}
+                className={inputClass}
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/migrations.ts
+++ b/src/migrations.ts
@@ -13,7 +13,7 @@
 import { createDefaultLayout } from "./titleBlockLayout";
 import { DEFAULT_CONNECTOR } from "./connectorTypes";
 
-export const CURRENT_SCHEMA_VERSION = 27;
+export const CURRENT_SCHEMA_VERSION = 28;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Migration = (data: any) => any;
@@ -330,6 +330,14 @@ const migrations: Record<number, Migration> = {
     }
     delete data.hideDeviceTypes;
     data.version = 27;
+    return data;
+  },
+  27: (data) => {
+    // v27 → v28: add optional roomDistances + distanceSettings for inter-room
+    // cable-length estimation (#146). No data transform needed — fields default
+    // to undefined and are populated on-demand when the user opens the new
+    // Room Distances dialog.
+    data.version = 28;
     return data;
   },
 };

--- a/src/reportLayout.ts
+++ b/src/reportLayout.ts
@@ -292,6 +292,7 @@ export function createDefaultCableScheduleLayout(): ReportLayout {
           { key: "cableType",       header: "Cable Type",  widthMm: 22, visible: true },
           { key: "signalType",      header: "Signal",      widthMm: 20, visible: true },
           { key: "cableLength",     header: "Length",      widthMm: 16, visible: true },
+          { key: "computedLength",  header: "Est. Length", widthMm: 18, visible: false },
           { key: "sourceRoom",      header: "Src Room",    widthMm: 24, visible: true },
           { key: "targetRoom",      header: "Tgt Room",    widthMm: 24, visible: true },
           { key: "multicableLabel", header: "Snake",       widthMm: 24, visible: true },

--- a/src/roomDistance.ts
+++ b/src/roomDistance.ts
@@ -1,0 +1,96 @@
+/**
+ * Helpers for inter-room distance and estimated cable-length calculation (#146).
+ *
+ * Distances are stored pairwise on SchematicFile.roomDistances, keyed by a
+ * canonical sorted "idA|idB" string so the lookup is symmetric. Devices in
+ * nested subrooms inherit their top-level ancestor's distance.
+ */
+
+import type { DistanceSettings, RoomData, SchematicFile, SchematicNode } from "./types";
+
+/** Canonical, sort-stable key for a symmetric pair of room IDs. */
+export function pairKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+/**
+ * Walk the parentId chain upward from a room and return the top-level ancestor.
+ * Returns the input ID unchanged if the room has no parent, or if the ID does
+ * not correspond to a room node (defensive fallback).
+ */
+export function getTopLevelRoomId(
+  roomId: string | undefined,
+  nodes: SchematicNode[],
+): string | undefined {
+  if (!roomId) return undefined;
+  let currentId: string | undefined = roomId;
+  let lastRoomId: string | undefined = undefined;
+  const seen = new Set<string>();
+  while (currentId && !seen.has(currentId)) {
+    seen.add(currentId);
+    const node = nodes.find((n) => n.id === currentId);
+    if (!node || node.type !== "room") break;
+    lastRoomId = currentId;
+    currentId = node.parentId as string | undefined;
+  }
+  return lastRoomId;
+}
+
+/** True if the given room has no room-type ancestor — i.e. it's a top-level room. */
+export function isTopLevelRoom(
+  roomId: string,
+  nodes: SchematicNode[],
+): boolean {
+  const node = nodes.find((n) => n.id === roomId);
+  if (!node || node.type !== "room") return false;
+  const parentId = node.parentId as string | undefined;
+  if (!parentId) return true;
+  const parent = nodes.find((n) => n.id === parentId);
+  return !parent || parent.type !== "room";
+}
+
+/** List all top-level rooms in display order, returning [id, label] tuples. */
+export function listTopLevelRooms(
+  nodes: SchematicNode[],
+): Array<{ id: string; label: string }> {
+  return nodes
+    .filter((n) => n.type === "room" && isTopLevelRoom(n.id, nodes))
+    .map((n) => ({
+      id: n.id,
+      label: (n.data as RoomData).label || "Unnamed",
+    }));
+}
+
+/**
+ * Resolve the stored distance between two rooms. Accepts IDs for top-level or
+ * nested rooms; nested rooms are walked up to their top-level ancestors before
+ * the lookup. Returns undefined when either room is missing, the two resolve
+ * to the same top-level room, or no distance has been set.
+ */
+export function getRoomDistance(
+  fromRoomId: string | undefined,
+  toRoomId: string | undefined,
+  file: Pick<SchematicFile, "roomDistances">,
+  nodes: SchematicNode[],
+): number | undefined {
+  const a = getTopLevelRoomId(fromRoomId, nodes);
+  const b = getTopLevelRoomId(toRoomId, nodes);
+  if (!a || !b || a === b) return undefined;
+  return file.roomDistances?.[pairKey(a, b)];
+}
+
+/** distance × (1 + slack%/100) + slackFixed, clamped to non-negative. */
+export function computeCableLength(
+  distance: number,
+  settings: DistanceSettings,
+): number {
+  const pct = Number.isFinite(settings.slackPercent) ? settings.slackPercent : 0;
+  const fixed = Number.isFinite(settings.slackFixed) ? settings.slackFixed : 0;
+  const value = distance * (1 + pct / 100) + fixed;
+  return value < 0 ? 0 : value;
+}
+
+/** Format a length value for display, e.g. "117.0 m" or "42.5 ft". */
+export function formatLength(value: number, unit: DistanceSettings["unit"]): string {
+  return `${value.toFixed(1)} ${unit}`;
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -25,8 +25,9 @@ import type {
   CustomTemplateMeta,
 } from "./types";
 import type { ReactFlowInstance } from "@xyflow/react";
-import type { SignalType, ScrollConfig, LineStyle, LabelCaseMode } from "./types";
-import { DEFAULT_SCROLL_CONFIG, DEFAULT_LABEL_CASE } from "./types";
+import type { SignalType, ScrollConfig, LineStyle, LabelCaseMode, DistanceSettings } from "./types";
+import { DEFAULT_SCROLL_CONFIG, DEFAULT_LABEL_CASE, DEFAULT_DISTANCE_SETTINGS } from "./types";
+import { pairKey } from "./roomDistance";
 import type { Orientation } from "./printConfig";
 import { computeAlignment, resolveAlignmentOverlaps, type AlignOperation } from "./alignUtils";
 import { CURRENT_SCHEMA_VERSION, migrateSchematic } from "./migrations";
@@ -350,6 +351,12 @@ interface SchematicState {
   colorKeyOverrides: Partial<Record<SignalType, boolean>> | undefined;
   cableCosts: Record<string, number> | undefined;
   setCableCost: (key: string, cost: number | undefined) => void;
+  // Room distance + cable-length estimation (#146)
+  roomDistances: Record<string, number> | undefined;
+  distanceSettings: DistanceSettings | undefined;
+  setRoomDistance: (roomIdA: string, roomIdB: string, distance: number | undefined) => void;
+  clearRoomDistance: (roomIdA: string, roomIdB: string) => void;
+  setDistanceSettings: (partial: Partial<DistanceSettings>) => void;
   setColorKeyEnabled: (v: boolean) => void;
   setColorKeyCorner: (c: "top-left" | "top-right" | "bottom-left" | "bottom-right") => void;
   setColorKeyColumns: (n: number) => void;
@@ -906,6 +913,8 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
   colorKeyPage: "all" as "first" | "last" | "all",
   colorKeyOverrides: undefined,
   cableCosts: undefined,
+  roomDistances: undefined,
+  distanceSettings: undefined,
   titleBlock: { showName: "", venue: "", designer: "", engineer: "", date: "", drawingTitle: "", company: "", revision: "", logo: "", customFields: [] },
   titleBlockLayout: createDefaultLayout(),
   signalColors: undefined,
@@ -1236,9 +1245,23 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
         return n;
       });
 
+    // Purge any pairwise distances referencing a deleted room (#146).
+    let nextDistances = state.roomDistances;
+    if (state.roomDistances && deletedRoomIds.size > 0) {
+      const filtered: Record<string, number> = {};
+      for (const [key, value] of Object.entries(state.roomDistances)) {
+        const [a, b] = key.split("|");
+        if (!deletedRoomIds.has(a) && !deletedRoomIds.has(b)) {
+          filtered[key] = value;
+        }
+      }
+      nextDistances = Object.keys(filtered).length > 0 ? filtered : undefined;
+    }
+
     set({
       nodes: renumberNodes(remainingNodes),
       edges: newEdges,
+      ...(nextDistances !== state.roomDistances ? { roomDistances: nextDistances } : {}),
     });
     get().saveToLocalStorage();
   },
@@ -2496,6 +2519,33 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
     set({ cableCosts: Object.keys(current).length > 0 ? current : undefined });
     get().saveToLocalStorage();
   },
+  setRoomDistance: (roomIdA, roomIdB, distance) => {
+    if (roomIdA === roomIdB) return;
+    const current = { ...(get().roomDistances ?? {}) };
+    const key = pairKey(roomIdA, roomIdB);
+    if (distance == null || !Number.isFinite(distance) || distance <= 0) {
+      delete current[key];
+    } else {
+      current[key] = distance;
+    }
+    set({ roomDistances: Object.keys(current).length > 0 ? current : undefined });
+    get().saveToLocalStorage();
+  },
+  clearRoomDistance: (roomIdA, roomIdB) => {
+    get().setRoomDistance(roomIdA, roomIdB, undefined);
+  },
+  setDistanceSettings: (partial) => {
+    const merged: DistanceSettings = {
+      ...DEFAULT_DISTANCE_SETTINGS,
+      ...(get().distanceSettings ?? {}),
+      ...partial,
+    };
+    // Clamp slack values so UI-typed garbage never propagates.
+    if (!Number.isFinite(merged.slackPercent) || merged.slackPercent < 0) merged.slackPercent = 0;
+    if (!Number.isFinite(merged.slackFixed) || merged.slackFixed < 0) merged.slackFixed = 0;
+    set({ distanceSettings: merged });
+    get().saveToLocalStorage();
+  },
   setTitleBlock: (tb) => { set({ titleBlock: tb }); get().saveToLocalStorage(); },
   setTitleBlockLayout: (layout) => { set({ titleBlockLayout: layout }); get().saveToLocalStorage(); },
 
@@ -2766,6 +2816,8 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
       colorKeyPage: state.colorKeyPage !== "all" ? state.colorKeyPage : undefined,
       colorKeyOverrides: state.colorKeyOverrides && Object.keys(state.colorKeyOverrides).length > 0 ? state.colorKeyOverrides : undefined,
       cableCosts: state.cableCosts && Object.keys(state.cableCosts).length > 0 ? state.cableCosts : undefined,
+      roomDistances: state.roomDistances && Object.keys(state.roomDistances).length > 0 ? state.roomDistances : undefined,
+      distanceSettings: state.distanceSettings,
     };
     // Persist cloud identity alongside autosave (not part of SchematicFile export)
     const blob: Record<string, unknown> = { ...data };
@@ -2849,6 +2901,8 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
             colorKeyPage: data.colorKeyPage ?? "all",
             colorKeyOverrides: data.colorKeyOverrides ?? undefined,
             cableCosts: data.cableCosts ?? undefined,
+            roomDistances: data.roomDistances ?? undefined,
+            distanceSettings: data.distanceSettings ?? undefined,
           });
           hydrated = true;
           get().saveToLocalStorage();
@@ -2916,6 +2970,8 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
         colorKeyPage: data.colorKeyPage ?? "all",
         colorKeyOverrides: data.colorKeyOverrides ?? undefined,
         cableCosts: data.cableCosts ?? undefined,
+        roomDistances: data.roomDistances ?? undefined,
+        distanceSettings: data.distanceSettings ?? undefined,
         // Restore cloud identity from autosave (not part of SchematicFile)
         cloudSchematicId: parsed.cloudSchematicId ?? null,
         cloudSavedAt: parsed.cloudSavedAt ?? null,
@@ -2982,6 +3038,8 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
       colorKeyPage: state.colorKeyPage !== "all" ? state.colorKeyPage : undefined,
       colorKeyOverrides: state.colorKeyOverrides && Object.keys(state.colorKeyOverrides).length > 0 ? state.colorKeyOverrides : undefined,
       cableCosts: state.cableCosts && Object.keys(state.cableCosts).length > 0 ? state.cableCosts : undefined,
+      roomDistances: state.roomDistances && Object.keys(state.roomDistances).length > 0 ? state.roomDistances : undefined,
+      distanceSettings: state.distanceSettings,
     };
   },
 
@@ -3067,6 +3125,8 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
       colorKeyPage: data.colorKeyPage ?? "all",
       colorKeyOverrides: data.colorKeyOverrides ?? undefined,
       cableCosts: data.cableCosts ?? undefined,
+      roomDistances: data.roomDistances ?? undefined,
+      distanceSettings: data.distanceSettings ?? undefined,
       // File imports and shared schematics always start as local-only
       cloudSchematicId: null,
       cloudSavedAt: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -538,7 +538,7 @@ export interface DistanceSettings {
 }
 
 export const DEFAULT_DISTANCE_SETTINGS: DistanceSettings = {
-  unit: "m",
+  unit: "ft",
   slackPercent: 15,
   slackFixed: 0,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -518,10 +518,28 @@ export interface SchematicFile {
   cableCosts?: Record<string, number>;
   /** Force-case device/port/slot labels on write (normal = leave as-typed) */
   labelCase?: LabelCaseMode;
+  /** Pairwise distances between top-level rooms; key is canonical pairKey("idA","idB"). */
+  roomDistances?: Record<string, number>;
+  /** Unit + slack settings for converting room distance → estimated cable length (#146). */
+  distanceSettings?: DistanceSettings;
 }
 
 export type LabelCaseMode = "as-typed" | "uppercase" | "lowercase" | "capitalize";
 export const DEFAULT_LABEL_CASE: LabelCaseMode = "as-typed";
+
+export interface DistanceSettings {
+  unit: "m" | "ft";
+  /** Additional slack as a percentage of the room-to-room distance (e.g. 15 = +15%). */
+  slackPercent: number;
+  /** Additional slack added after percent (same unit as distance). */
+  slackFixed: number;
+}
+
+export const DEFAULT_DISTANCE_SETTINGS: DistanceSettings = {
+  unit: "m",
+  slackPercent: 15,
+  slackFixed: 0,
+};
 
 export type ScrollAction = "zoom" | "pan-x" | "pan-y";
 


### PR DESCRIPTION
## Description
## Summary

Adds room-to-room distance tracking and uses it to estimate cable lengths between connected devices (closes #146).

- New **Room Distances** dialog under the Reports menu lets you set the distance between any two top-level rooms, plus a global unit (ft/m) and slack (percent + fixed amount).
- Distances can also be set directly from the Room editor.
- Cable Schedule and Hookup Sheet show a new **Est. Length** column. Your manually-entered cable lengths are never overwritten.
- Devices in nested subrooms automatically inherit the distance of their parent room.
## Testing
testing in local docker instance
## Screenshots

<!-- If this is a UI change, include before/after screenshots. -->
<img width="665" height="512" alt="Screenshot 2026-04-26 235428" src="https://github.com/user-attachments/assets/b5faa6ed-da6a-4236-8246-a1214704b360" />
<img width="457" height="730" alt="Screenshot 2026-04-26 235448" src="https://github.com/user-attachments/assets/f30c27fa-3bcc-4e4a-8034-7bb53b546793" />
<img width="1122" height="664" alt="Screenshot 2026-04-26 235513" src="https://github.com/user-attachments/assets/86d216c8-63e0-433e-8274-d445436ea7fe" />

