### PR TITLE
Add live MCP bridge (Beta): let an AI assistant read & edit a schematic

### DIFF
--- a/docs/src/DocsApp.tsx
+++ b/docs/src/DocsApp.tsx
@@ -16,6 +16,7 @@ import PrintingPage from "./pages/Printing";
 import PackListPage from "./pages/PackList";
 import ApiPage from "./pages/Api";
 import SelfHostingPage from "./pages/SelfHosting";
+import AiAssistantPage from "./pages/AiAssistant";
 import RacksPage from "./pages/Racks";
 import PrintSheetsPage from "./pages/PrintSheets";
 
@@ -37,6 +38,7 @@ const routes: Record<string, { title: string; component: React.FC }> = {
   "import-devices": { title: "Import Devices", component: ImportDevicesPage },
   "device-template-schema": { title: "Device Template Schema", component: DeviceTemplateSchemaPage },
   "self-hosting": { title: "Self-Hosting", component: SelfHostingPage },
+  "ai-assistant": { title: "AI Assistant (MCP)", component: AiAssistantPage },
   api: { title: "Public API", component: ApiPage },
 };
 

--- a/docs/src/components/Layout.tsx
+++ b/docs/src/components/Layout.tsx
@@ -22,6 +22,7 @@ const navItems = [
   { hash: "import-devices", label: "Import Devices" },
   { hash: "device-template-schema", label: "Device Template Schema" },
   { hash: "self-hosting", label: "Self-Hosting" },
+  { hash: "ai-assistant", label: "AI Assistant (MCP)" },
   { hash: "api", label: "Public API" },
 ];
 

--- a/docs/src/pages/AiAssistant.tsx
+++ b/docs/src/pages/AiAssistant.tsx
@@ -1,0 +1,123 @@
+export default function AiAssistantPage() {
+  return (
+    <>
+      <h1>AI Assistant (MCP)</h1>
+
+      <p>
+        EasySchematic can connect to an AI assistant (such as Claude) so it can{" "}
+        <strong>read and edit your schematic live</strong> — searching the device
+        library, adding devices, setting device properties, and making
+        connections, with the results appearing on your canvas as it works. This
+        is an early <strong>Beta</strong> and is turned off by default.
+      </p>
+
+      <div
+        className="border-l-4 border-blue-400 bg-blue-50 p-4 rounded-r my-4"
+        role="note"
+      >
+        <strong>How it works:</strong> a small program called the{" "}
+        <em>MCP server</em> runs on your own computer. The assistant talks to that
+        server, and the server talks to your open EasySchematic tab over a
+        connection that stays on your machine (<code>127.0.0.1</code> only). Your
+        drawing is reachable only while you turn the setting on, and only after a
+        one-time <strong>pairing token</strong> is matched.
+      </div>
+
+      <h2>1. Start the MCP server</h2>
+
+      <p>
+        The server lives in the <code>mcp-server</code> folder of the project. Build
+        it once, then run it:
+      </p>
+
+      <pre>
+        <code>{`cd mcp-server
+npm install
+npm run build
+
+node dist/index.js`}</code>
+      </pre>
+
+      <p>
+        On startup it prints a <strong>pairing token</strong> and the port it is
+        listening on (default <code>8765</code>).
+      </p>
+
+      <h2>2. Turn it on in EasySchematic</h2>
+
+      <ol>
+        <li>
+          Open <strong>Preferences → AI (Beta)</strong>.
+        </li>
+        <li>Paste the <strong>pairing token</strong> the server printed.</li>
+        <li>
+          Make sure the <strong>port</strong> matches the server (default 8765).
+        </li>
+        <li>
+          Turn on <strong>“Let Claude read &amp; edit this schematic.”</strong> The
+          status should change to <em>Connected</em>.
+        </li>
+      </ol>
+
+      <p>
+        Only one tab is connected at a time — the most recent tab where you turn
+        the setting on takes over, and any earlier tab shows <em>Not connected</em>.
+      </p>
+
+      <h2>3. Register the server with your assistant</h2>
+
+      <p>
+        Point your assistant's MCP configuration at the server. With Claude Code,
+        for example:
+      </p>
+
+      <pre>
+        <code>{`claude mcp add easyschematic -- node /absolute/path/to/EasySchematic/mcp-server/dist/index.js`}</code>
+      </pre>
+
+      <p>
+        Then you can ask things like <em>“search for a 4K display, add it, and
+        connect the laptop's HDMI output to it.”</em>
+      </p>
+
+      <h2>What it can do in Beta</h2>
+
+      <p>The assistant has a core set of tools:</p>
+
+      <ul>
+        <li>
+          <strong>Read</strong> — view the schematic, list devices, inspect one
+          device, and search the device library.
+        </li>
+        <li>
+          <strong>Add a device</strong> from a library template.
+        </li>
+        <li>
+          <strong>Set device properties</strong> — a safe set such as label,
+          short name, manufacturer, model number, note, serial number, unit cost,
+          and power figures. Structural fields (ports, slots) are not editable yet
+          and are refused.
+        </li>
+        <li>
+          <strong>Connect two devices</strong>. For two-sided ports the assistant
+          specifies a face — bidirectional ports use <code>in</code>/<code>out</code>,
+          passthrough ports use <code>rear</code>/<code>front</code>. Every
+          connection is validated before it is made.
+        </li>
+        <li>
+          <strong>Delete a device.</strong>
+        </li>
+      </ul>
+
+      <div
+        className="border-l-4 border-amber-400 bg-amber-50 p-4 rounded-r my-4"
+        role="note"
+      >
+        <strong>Security:</strong> the connection never leaves your computer, is
+        off until you enable it, and requires the pairing token. If you self-host
+        EasySchematic on a non-localhost address, set{" "}
+        <code>EASYSCHEMATIC_MCP_ORIGINS</code> on the server to allow that origin.
+      </div>
+    </>
+  );
+}

--- a/mcp-server/.gitignore
+++ b/mcp-server/.gitignore
@@ -1,0 +1,4 @@
+dist/
+node_modules/
+# Single-source: generated from ../src/mcp/protocol.ts by scripts/sync-protocol.mjs
+src/protocol.generated.ts

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,77 @@
+# EasySchematic MCP server (Beta)
+
+A small local program that lets an AI assistant (Claude) **read and edit a schematic
+live** in your running EasySchematic editor. It speaks [MCP](https://modelcontextprotocol.io)
+to the assistant over stdio, and connects to the editor over a localhost WebSocket.
+
+> Beta — only a core set of actions is supported: read the schematic, search the
+> device library, add a device, set safe device properties, connect devices, and
+> delete a device.
+
+## How it fits together
+
+```
+Claude (MCP client)  ──stdio──▶  easyschematic-mcp  ──ws://127.0.0.1──▶  EasySchematic tab
+```
+
+The server never listens on the public network — the WebSocket binds to
+`127.0.0.1` only — and a tab must present a **pairing token** (and an allowed
+Origin) before any command runs.
+
+## Build
+
+This package is self-contained (it is **not** built by the main app's
+`npm run build` or by CI). Build it once:
+
+```bash
+cd mcp-server
+npm install
+npm run build        # also regenerates the shared protocol file from ../src/mcp
+```
+
+## Run
+
+```bash
+node mcp-server/dist/index.js
+```
+
+On startup it prints (to stderr) a **pairing token** and the port it is listening
+on. Configure with environment variables if needed:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `EASYSCHEMATIC_MCP_PORT` | `8765` | WebSocket port (must match the app's setting). |
+| `EASYSCHEMATIC_MCP_TOKEN` | random | Fixed pairing token (otherwise a new one each run). |
+| `EASYSCHEMATIC_MCP_ORIGINS` | — | Comma-separated extra allowed Origins for self-hosted editors on a non-localhost domain. |
+
+## Connect the editor
+
+1. Open EasySchematic and go to **Preferences → AI (Beta)**.
+2. Paste the **pairing token** the server printed.
+3. Make sure the **port** matches (default 8765).
+4. Turn on **“Let Claude read & edit this schematic.”** The status should read *Connected*.
+
+Only one tab is bound at a time — the most recent tab you enable claims the
+connection; an earlier tab shows *Not connected*.
+
+## Register with Claude Code
+
+Add the server to your MCP config so Claude can attach to it, e.g.:
+
+```bash
+claude mcp add easyschematic -- node /absolute/path/to/EasySchematic/mcp-server/dist/index.js
+```
+
+Then ask Claude things like *“search for a 4K display, add it, and connect the
+laptop's HDMI output to it.”*
+
+## Develop
+
+```bash
+npm run typecheck   # regenerate protocol + tsc --noEmit
+npm test            # build + node --test (origin/token unit tests)
+```
+
+The wire protocol is defined once in `../src/mcp/protocol.ts` and copied here as
+`src/protocol.generated.ts` by `scripts/sync-protocol.mjs` on every build, so the
+two sides can never drift.

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,0 +1,1244 @@
+{
+  "name": "easyschematic-mcp-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "easyschematic-mcp-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.10.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "easyschematic-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.5.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "easyschematic-mcp-server",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Local MCP server that bridges Claude to a running EasySchematic editor (Beta).",
+  "bin": {
+    "easyschematic-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "sync": "node scripts/sync-protocol.mjs",
+    "prebuild": "node scripts/sync-protocol.mjs",
+    "build": "tsc",
+    "typecheck": "node scripts/sync-protocol.mjs && tsc --noEmit",
+    "pretest": "npm run build",
+    "test": "node --test dist/*.test.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.10.0",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/mcp-server/scripts/sync-protocol.mjs
+++ b/mcp-server/scripts/sync-protocol.mjs
@@ -1,0 +1,16 @@
+// Copies the canonical wire protocol from the app into this package so there is
+// exactly ONE source of truth (src/mcp/protocol.ts). The copy is gitignored and
+// regenerated on every build/test, so it can never silently drift.
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = resolve(here, "../../src/mcp/protocol.ts");
+const dest = resolve(here, "../src/protocol.generated.ts");
+
+const banner =
+  "// AUTO-GENERATED from src/mcp/protocol.ts — do not edit. Regenerate with `npm run sync`.\n";
+mkdirSync(dirname(dest), { recursive: true });
+writeFileSync(dest, banner + readFileSync(src, "utf8"));
+process.stderr.write(`[sync-protocol] wrote ${dest}\n`);

--- a/mcp-server/src/bridge.ts
+++ b/mcp-server/src/bridge.ts
@@ -1,0 +1,140 @@
+import type { IncomingMessage } from "node:http";
+import { WebSocketServer, WebSocket } from "ws";
+import { isOriginAllowed, tokensMatch } from "./security.js";
+import { PROTOCOL_VERSION } from "./protocol.generated.js";
+
+export interface BridgeOptions {
+  port: number;
+  token: string;
+  allowedOrigins: string[];
+  requestTimeoutMs?: number;
+  log: (msg: string) => void;
+}
+
+interface Pending {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+/**
+ * Hosts the localhost WebSocket the editor dials into, and relays MCP tool calls
+ * to the single bound tab. Enforces the token + origin handshake and a one-active-
+ * connection model (a new authenticated tab supersedes the previous one).
+ */
+export class AppBridge {
+  private wss: WebSocketServer | null = null;
+  private active: WebSocket | null = null;
+  private readonly pending = new Map<string, Pending>();
+  private seq = 0;
+
+  constructor(private readonly opts: BridgeOptions) {}
+
+  start(): void {
+    this.wss = new WebSocketServer({ host: "127.0.0.1", port: this.opts.port });
+    this.wss.on("connection", (ws, req) => this.onConnection(ws, req));
+    this.wss.on("error", (err) => this.opts.log(`WebSocket server error: ${err.message}`));
+  }
+
+  get connected(): boolean {
+    return this.active !== null && this.active.readyState === WebSocket.OPEN;
+  }
+
+  private onConnection(ws: WebSocket, req: IncomingMessage): void {
+    if (!isOriginAllowed(req.headers.origin, this.opts.allowedOrigins)) {
+      this.opts.log(`Rejected connection from disallowed origin: ${req.headers.origin ?? "(none)"}`);
+      ws.close();
+      return;
+    }
+    let helloed = false;
+
+    ws.on("message", (data: WebSocket.RawData) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        return;
+      }
+
+      if (!helloed) {
+        if (msg.type !== "hello") {
+          ws.close();
+          return;
+        }
+        if (msg.protocolVersion !== PROTOCOL_VERSION) {
+          ws.send(JSON.stringify({ type: "hello_ack", ok: false, reason: "Protocol version mismatch — update the MCP server." }));
+          ws.close();
+          return;
+        }
+        if (!tokensMatch(String(msg.token ?? ""), this.opts.token)) {
+          ws.send(JSON.stringify({ type: "hello_ack", ok: false, reason: "Invalid pairing token." }));
+          ws.close();
+          return;
+        }
+        helloed = true;
+        // Single active binding: supersede any previously bound tab.
+        if (this.active && this.active !== ws) {
+          try {
+            this.active.send(JSON.stringify({ type: "superseded", reason: "Another EasySchematic tab took the AI connection." }));
+            this.active.close();
+          } catch {
+            /* ignore */
+          }
+          this.rejectAllPending(new Error("Connection superseded by a new tab."));
+        }
+        this.active = ws;
+        ws.send(JSON.stringify({ type: "hello_ack", ok: true }));
+        this.opts.log(`EasySchematic connected (schematic: ${String(msg.schematicName ?? "untitled")}).`);
+        return;
+      }
+
+      if (msg.type === "response" && typeof msg.requestId === "string") {
+        const p = this.pending.get(msg.requestId);
+        if (!p) return;
+        this.pending.delete(msg.requestId);
+        clearTimeout(p.timer);
+        if (msg.ok) p.resolve(msg.result);
+        else p.reject(new Error(String(msg.error || "Command failed.")));
+      }
+    });
+
+    ws.on("close", () => {
+      if (this.active === ws) {
+        this.active = null;
+        this.rejectAllPending(new Error("EasySchematic disconnected."));
+        this.opts.log("EasySchematic disconnected.");
+      }
+    });
+    ws.on("error", () => {
+      /* surfaced via the close handler */
+    });
+  }
+
+  private rejectAllPending(err: Error): void {
+    for (const p of this.pending.values()) {
+      clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  /** Send a command to the bound tab and await its correlated response. */
+  call(command: string, params: Record<string, unknown>): Promise<unknown> {
+    if (!this.connected || !this.active) {
+      return Promise.reject(
+        new Error("No EasySchematic app is connected. Open the editor and turn on AI Assistant (MCP) in Preferences."),
+      );
+    }
+    const requestId = `req-${++this.seq}`;
+    const timeoutMs = this.opts.requestTimeoutMs ?? 15000;
+    const socket = this.active;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(new Error(`Timed out waiting for EasySchematic to handle "${command}".`));
+      }, timeoutMs);
+      this.pending.set(requestId, { resolve, reject, timer });
+      socket.send(JSON.stringify({ type: "command", requestId, command, params }));
+    });
+  }
+}

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * EasySchematic MCP server (Beta).
+ *
+ * Speaks MCP to Claude over stdio, and hosts a localhost WebSocket the running
+ * editor connects to. Tool calls from Claude are relayed to the bound tab, which
+ * executes them against the live schematic and replies.
+ *
+ * IMPORTANT: stdout is reserved for the MCP stdio protocol — all human-facing
+ * logging goes to stderr.
+ */
+import { randomBytes } from "node:crypto";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { AppBridge } from "./bridge.js";
+import { TOOLS } from "./tools.js";
+import { DEFAULT_BRIDGE_PORT } from "./protocol.generated.js";
+
+const log = (msg: string) => process.stderr.write(`[easyschematic-mcp] ${msg}\n`);
+
+const port = Number(process.env.EASYSCHEMATIC_MCP_PORT) || DEFAULT_BRIDGE_PORT;
+const token = process.env.EASYSCHEMATIC_MCP_TOKEN || randomBytes(16).toString("hex");
+const allowedOrigins = (process.env.EASYSCHEMATIC_MCP_ORIGINS || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const bridge = new AppBridge({ port, token, allowedOrigins, log });
+bridge.start();
+
+log("");
+log(`WebSocket bridge listening on ws://127.0.0.1:${port}`);
+log(`Pairing token: ${token}`);
+log("Paste this token into EasySchematic → Preferences → AI (Beta), then turn the toggle on.");
+log("");
+
+const server = new Server({ name: "easyschematic", version: "0.1.0" }, { capabilities: { tools: {} } });
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const { name, arguments: args } = req.params;
+  try {
+    const result = await bridge.call(name, (args ?? {}) as Record<string, unknown>);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { content: [{ type: "text", text: message }], isError: true };
+  }
+});
+
+await server.connect(new StdioServerTransport());
+log("MCP server ready (stdio). Waiting for the editor to connect…");

--- a/mcp-server/src/security.test.ts
+++ b/mcp-server/src/security.test.ts
@@ -1,0 +1,25 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isOriginAllowed, tokensMatch } from "./security.js";
+
+test("tokensMatch: equal tokens match, others do not", () => {
+  assert.equal(tokensMatch("abc123", "abc123"), true);
+  assert.equal(tokensMatch("abc123", "abc124"), false);
+  assert.equal(tokensMatch("abc", "abc123"), false); // length mismatch
+  assert.equal(tokensMatch("", ""), false); // empty never matches
+});
+
+test("isOriginAllowed: localhost allowed by default", () => {
+  assert.equal(isOriginAllowed("http://localhost:5173", []), true);
+  assert.equal(isOriginAllowed("http://127.0.0.1:4173", []), true);
+});
+
+test("isOriginAllowed: foreign origin rejected unless explicitly allowed", () => {
+  assert.equal(isOriginAllowed("https://evil.example.com", []), false);
+  assert.equal(isOriginAllowed("https://app.mysite.com", ["https://app.mysite.com"]), true);
+});
+
+test("isOriginAllowed: missing or malformed origin rejected", () => {
+  assert.equal(isOriginAllowed(undefined, []), false);
+  assert.equal(isOriginAllowed("not-a-url", []), false);
+});

--- a/mcp-server/src/security.ts
+++ b/mcp-server/src/security.ts
@@ -1,0 +1,28 @@
+import { timingSafeEqual } from "node:crypto";
+
+/** Constant-time compare of the pairing token. Returns false on any length/empty
+ *  mismatch without leaking timing about how much matched. */
+export function tokensMatch(provided: string, expected: string): boolean {
+  if (!provided || !expected) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Origin allowlist — defense-in-depth on top of the token. Browsers always send
+ * an Origin header on a WebSocket handshake, so a missing Origin is rejected.
+ * localhost / 127.0.0.1 (any port) are allowed by default for the dev & preview
+ * servers; self-hosters on another domain add it via EASYSCHEMATIC_MCP_ORIGINS.
+ */
+export function isOriginAllowed(origin: string | undefined, allowed: string[]): boolean {
+  if (!origin) return false;
+  if (allowed.includes(origin)) return true;
+  try {
+    const host = new URL(origin).hostname;
+    return host === "localhost" || host === "127.0.0.1";
+  } catch {
+    return false;
+  }
+}

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,0 +1,114 @@
+/**
+ * MCP tool catalog for Ship 1 ("working core"). Each entry is a plain JSON-Schema
+ * tool definition; the call is relayed verbatim to the editor over the bridge,
+ * which validates and executes it against the live store.
+ *
+ * In AV terms the user sees Device / Connection / Port; these tool names and the
+ * docs use the same AV language.
+ */
+export interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+const noArgs = { type: "object", properties: {}, additionalProperties: false };
+
+export const TOOLS: ToolDef[] = [
+  {
+    name: "get_schematic",
+    description:
+      "Get a summary of the current schematic: its name, every device (with ports) and every connection. Call this first to see what already exists.",
+    inputSchema: noArgs,
+  },
+  {
+    name: "list_devices",
+    description: "List the devices on the canvas with their ids, labels, type, manufacturer and position.",
+    inputSchema: noArgs,
+  },
+  {
+    name: "get_device",
+    description: "Get one device's details, including its ports (id, label, direction, signal type).",
+    inputSchema: {
+      type: "object",
+      properties: { nodeId: { type: "string", description: "The device id." } },
+      required: ["nodeId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "search_templates",
+    description:
+      "Search the device template library (community library + this schematic's custom devices) by name, type or manufacturer. Returns templateId values to pass to add_device.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: { type: "string", description: "Free-text search, e.g. 'crestron switcher' or 'display'." },
+        limit: { type: "number", description: "Max results (default 25)." },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "add_device",
+    description:
+      "Add a device to the canvas from a template. Use search_templates to get a templateId. Returns the new device's id.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        templateId: { type: "string", description: "Template id from search_templates." },
+        label: { type: "string", description: "Optional custom name; defaults to the template name." },
+        x: { type: "number", description: "Optional canvas X position." },
+        y: { type: "number", description: "Optional canvas Y position." },
+      },
+      required: ["templateId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "set_device_property",
+    description:
+      "Set safe properties on a device (e.g. label, shortName, manufacturer, modelNumber, note, serialNumber, unitCost, power figures). Structural fields like ports and slots are not editable in this Beta and are rejected.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "The device id." },
+        properties: {
+          type: "object",
+          description: "Map of field name to new value (string, number or boolean).",
+        },
+      },
+      required: ["nodeId", "properties"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "connect_devices",
+    description:
+      "Create a connection from one device's port to another's. For two-sided ports give the face: bidirectional ports use 'in'/'out'; passthrough ports use 'rear'/'front'. Plain ports need no face. The connection is validated before it is made.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sourceNodeId: { type: "string" },
+        sourcePortId: { type: "string" },
+        sourceFace: { type: "string", enum: ["in", "out", "rear", "front"], description: "Required only for two-sided source ports." },
+        targetNodeId: { type: "string" },
+        targetPortId: { type: "string" },
+        targetFace: { type: "string", enum: ["in", "out", "rear", "front"], description: "Required only for two-sided target ports." },
+      },
+      required: ["sourceNodeId", "sourcePortId", "targetNodeId", "targetPortId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "delete_device",
+    description: "Delete a device (and its connections) from the canvas.",
+    inputSchema: {
+      type: "object",
+      properties: { nodeId: { type: "string", description: "The device id." } },
+      required: ["nodeId"],
+      additionalProperties: false,
+    },
+  },
+];

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import {
 } from "@xyflow/react";
 import { useSchematicStore, GRID_SIZE, setReconnectingEdgeId } from "./store";
 import { warmupRoutingWorker } from "./routing/routingClient";
+import { useMcpBridge } from "./mcpBridge";
 import { nodeTypes, edgeTypes } from "./nodeTypes";
 import SnapGuides from "./components/SnapGuides";
 import PageBoundaryOverlay from "./components/PageBoundaryOverlay";
@@ -1760,6 +1761,9 @@ export default function App() {
   const isSchematicActive = activePage === "schematic";
   const undo = useSchematicStore((s) => s.undo);
   const redo = useSchematicStore((s) => s.redo);
+
+  // MCP bridge (Beta): connect to the local MCP server when the user enables it.
+  useMcpBridge();
 
   // Keep the browser tab title in sync with the current schematic name, so it
   // reflects the active file (incl. after Save As / Open / rename). (#174)

--- a/src/__tests__/mcpValidation.test.ts
+++ b/src/__tests__/mcpValidation.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { classifyDeviceProperties, resolveHandleFromCandidates } from "../mcp/validation";
+
+describe("classifyDeviceProperties", () => {
+  it("routes label and shortName to their dedicated buckets", () => {
+    const r = classifyDeviceProperties({ label: "Main Display", shortName: "DISP-1" });
+    expect(r.label).toBe("Main Display");
+    expect(r.shortName).toBe("DISP-1");
+    expect(r.patch).toEqual({});
+    expect(r.applied.sort()).toEqual(["label", "shortName"]);
+    expect(r.rejected).toEqual([]);
+  });
+
+  it("collects safe scalar fields into patch", () => {
+    const r = classifyDeviceProperties({ manufacturer: "Crestron", unitCost: 1200, isSpare: true });
+    expect(r.patch).toEqual({ manufacturer: "Crestron", unitCost: 1200, isSpare: true });
+    expect(r.applied.sort()).toEqual(["isSpare", "manufacturer", "unitCost"]);
+  });
+
+  it("rejects non-scalar values for whitelisted fields (untrusted input)", () => {
+    const r = classifyDeviceProperties({
+      label: "OK",
+      unitCost: { bad: 1 },
+      note: ["nope"],
+      manufacturer: null,
+    } as Record<string, unknown>);
+    expect(r.applied).toEqual(["label"]);
+    expect(r.rejected.sort()).toEqual(["manufacturer", "note", "unitCost"]);
+    expect(r.patch).toEqual({});
+  });
+
+  it("rejects structural / unknown fields and never patches them", () => {
+    const r = classifyDeviceProperties({
+      label: "OK",
+      ports: "nope",
+      slots: "nope",
+      deviceType: "nope",
+      bogus: "nope",
+    } as Record<string, string>);
+    expect(r.applied).toEqual(["label"]);
+    expect(r.rejected.sort()).toEqual(["bogus", "deviceType", "ports", "slots"]);
+    expect(r.patch).toEqual({});
+  });
+});
+
+describe("resolveHandleFromCandidates", () => {
+  it("uses the only handle for a plain port (face ignored)", () => {
+    expect(resolveHandleFromCandidates(["hdmi1"], "hdmi1", undefined)).toEqual({
+      ok: true,
+      handleId: "hdmi1",
+    });
+  });
+
+  it("errors when the port is missing", () => {
+    const r = resolveHandleFromCandidates([], "hdmi1", undefined);
+    expect(r.ok).toBe(false);
+  });
+
+  it("requires a face for a two-sided bidirectional port", () => {
+    const r = resolveHandleFromCandidates(["lan-in", "lan-out"], "lan", undefined);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/two sides/);
+  });
+
+  it("selects the requested face for a passthrough port", () => {
+    expect(resolveHandleFromCandidates(["loop-rear", "loop-front"], "loop", "front")).toEqual({
+      ok: true,
+      handleId: "loop-front",
+    });
+  });
+
+  it("rejects an invalid face", () => {
+    const r = resolveHandleFromCandidates(["lan-in", "lan-out"], "lan", "rear");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/Invalid face/);
+  });
+});

--- a/src/components/PreferencesDialog.tsx
+++ b/src/components/PreferencesDialog.tsx
@@ -71,11 +71,19 @@ function SensitivityRow({
   );
 }
 
-type PrefTab = "canvas" | "display";
+type PrefTab = "canvas" | "display" | "ai";
 
 const TAB_LABELS: Record<PrefTab, string> = {
   canvas: "Canvas",
   display: "Display",
+  ai: "AI (Beta)",
+};
+
+const MCP_STATUS_LABELS: Record<string, string> = {
+  off: "Off",
+  connecting: "Connecting…",
+  connected: "Connected",
+  error: "Not connected",
 };
 
 export default function PreferencesDialog({ onClose }: { onClose: () => void }) {
@@ -101,6 +109,14 @@ export default function PreferencesDialog({ onClose }: { onClose: () => void }) 
   const setUseShortNames = useSchematicStore((s) => s.setUseShortNames);
   const wrapDeviceLabels = useSchematicStore((s) => s.wrapDeviceLabels);
   const setWrapDeviceLabels = useSchematicStore((s) => s.setWrapDeviceLabels);
+  const mcpEnabled = useSchematicStore((s) => s.mcpBridgeEnabled);
+  const setMcpEnabled = useSchematicStore((s) => s.setMcpBridgeEnabled);
+  const mcpToken = useSchematicStore((s) => s.mcpBridgeToken);
+  const setMcpToken = useSchematicStore((s) => s.setMcpBridgeToken);
+  const mcpPort = useSchematicStore((s) => s.mcpBridgePort);
+  const setMcpPort = useSchematicStore((s) => s.setMcpBridgePort);
+  const mcpStatus = useSchematicStore((s) => s.mcpBridgeStatus);
+  const mcpStatusDetail = useSchematicStore((s) => s.mcpBridgeStatusDetail);
   const [autoRoutePref, setAutoRoutePref] = useState(
     () => localStorage.getItem(AUTOROUTE_PREF_KEY) ?? "ask",
   );
@@ -473,6 +489,74 @@ export default function PreferencesDialog({ onClose }: { onClose: () => void }) 
                 </div>
                 <p className="text-[10px] text-[var(--color-text-muted)] mt-0.5">
                   Symbol used for cost fields in reports. All entered costs are assumed to be in this currency — no conversion is applied.
+                </p>
+              </div>
+            </>
+          )}
+
+          {activeTab === "ai" && (
+            <>
+              {/* AI Assistant (MCP) — Beta */}
+              <div>
+                <div className="text-[10px] uppercase tracking-wider text-[var(--color-text-muted)] mb-2">
+                  AI Assistant (MCP) — Beta
+                </div>
+                <label className="flex items-center justify-between py-1 cursor-pointer">
+                  <span className="text-xs text-[var(--color-text)]">Let Claude read &amp; edit this schematic</span>
+                  <input
+                    type="checkbox"
+                    checked={mcpEnabled}
+                    onChange={(e) => setMcpEnabled(e.target.checked)}
+                    className="cursor-pointer accent-blue-600"
+                  />
+                </label>
+                <p className="text-[10px] text-[var(--color-text-muted)] mt-0.5">
+                  Connects this tab to the EasySchematic MCP server running on your computer, so an AI assistant (Claude) can add devices, set properties, and make connections live. Off by default; your drawing is only reachable while this is on.
+                </p>
+
+                <div className="flex items-center justify-between py-1 mt-3">
+                  <span className="text-xs text-[var(--color-text)]">Pairing token</span>
+                  <input
+                    type="password"
+                    value={mcpToken}
+                    onChange={(e) => setMcpToken(e.target.value)}
+                    placeholder="Paste from the server"
+                    className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2 py-1 text-xs outline-none w-[180px]"
+                  />
+                </div>
+                <p className="text-[10px] text-[var(--color-text-muted)] mt-0.5">
+                  Copy the token the MCP server prints on startup and paste it here. This stops other programs on your computer from reaching the bridge.
+                </p>
+
+                <div className="flex items-center justify-between py-1 mt-3">
+                  <span className="text-xs text-[var(--color-text)]">Server port</span>
+                  <input
+                    type="number"
+                    value={mcpPort}
+                    onChange={(e) => setMcpPort(Number(e.target.value) || mcpPort)}
+                    className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded px-2 py-1 text-xs outline-none w-[100px]"
+                  />
+                </div>
+
+                <div className="flex items-center justify-between py-1 mt-3">
+                  <span className="text-xs text-[var(--color-text)]">Status</span>
+                  <span
+                    className={`text-xs font-medium ${
+                      mcpStatus === "connected"
+                        ? "text-green-600"
+                        : mcpStatus === "error"
+                          ? "text-red-600"
+                          : "text-[var(--color-text-muted)]"
+                    }`}
+                  >
+                    {MCP_STATUS_LABELS[mcpStatus] ?? mcpStatus}
+                  </span>
+                </div>
+                {mcpStatusDetail && (
+                  <p className="text-[10px] text-[var(--color-text-muted)] mt-0.5">{mcpStatusDetail}</p>
+                )}
+                <p className="text-[10px] text-[var(--color-text-muted)] mt-2">
+                  Setup help is in the docs under “AI Assistant (MCP)”. This is an early Beta — only a core set of actions is supported.
                 </p>
               </div>
             </>

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared wire protocol for the EasySchematic MCP bridge (Beta).
+ *
+ * This is the single source of truth for the messages exchanged between:
+ *   - the standalone MCP server (`mcp-server/`, a Node process Claude attaches to), and
+ *   - the in-app bridge (`src/mcpBridge.ts`, a WebSocket client inside the running editor).
+ *
+ * It MUST stay dependency-free (no imports from the rest of `src/`) so the server's
+ * own TypeScript build can include this exact file without pulling in the app. Keep it
+ * to plain types + constants.
+ */
+
+/** Default localhost port the MCP server listens on and the app dials. Both sides
+ *  share this constant; either may override it (server via env, app via the setting). */
+export const DEFAULT_BRIDGE_PORT = 8765;
+
+/** Bumped when the message shapes change incompatibly, so a mismatched server/app pair
+ *  refuses to pair instead of misbehaving. */
+export const PROTOCOL_VERSION = 1;
+
+/** The eight tools exposed in Ship 1 ("working core"). */
+export type CommandType =
+  | "get_schematic"
+  | "list_devices"
+  | "get_device"
+  | "search_templates"
+  | "add_device"
+  | "set_device_property"
+  | "connect_devices"
+  | "delete_device";
+
+/** Which two-sided face of a port to wire. Required only for bidirectional ports
+ *  (`in`/`out`) and passthrough ports (`rear`/`front`); ignored for plain ports. */
+export type PortFace = "in" | "out" | "rear" | "front";
+
+// ---------------------------------------------------------------------------
+// App -> server: handshake. The app proves it is the real editor (token) and the
+// server validates token + Origin before accepting any commands.
+// ---------------------------------------------------------------------------
+export interface HelloMessage {
+  type: "hello";
+  /** Pairing token the user copied from the server into the app's Preferences. */
+  token: string;
+  protocolVersion: number;
+  /** Stable id for this browser tab, so the server can report which tab is bound. */
+  clientId: string;
+  /** Human-friendly name of the open schematic, surfaced to Claude. */
+  schematicName?: string;
+}
+
+/** Server -> app: result of the handshake. */
+export interface HelloAck {
+  type: "hello_ack";
+  ok: boolean;
+  /** When ok=false, why pairing was refused (bad token, version mismatch, etc.). */
+  reason?: string;
+}
+
+/** Server -> app: a tool invocation to run against the store. */
+export interface CommandMessage {
+  type: "command";
+  requestId: string;
+  command: CommandType;
+  params: Record<string, unknown>;
+}
+
+/** App -> server: the correlated result of a CommandMessage. */
+export interface ResponseMessage {
+  type: "response";
+  requestId: string;
+  ok: boolean;
+  result?: unknown;
+  error?: string;
+}
+
+/** Server -> app: sent when this tab is being unbound because another tab claimed
+ *  the connection, so the app can show an honest "disconnected" status. */
+export interface SupersededMessage {
+  type: "superseded";
+  reason: string;
+}
+
+/** Messages the app may send to the server. */
+export type BridgeClientMessage = HelloMessage | ResponseMessage;
+/** Messages the server may send to the app. */
+export type BridgeServerMessage = HelloAck | CommandMessage | SupersededMessage;
+
+// ---------------------------------------------------------------------------
+// Tool parameter shapes (documented contract; validated on both ends).
+// ---------------------------------------------------------------------------
+export interface AddDeviceParams {
+  /** Template identity to instantiate — get one from `search_templates`. */
+  templateId: string;
+  /** Optional custom label; defaults to the template's name. */
+  label?: string;
+  /** Canvas position; defaults to a free spot near origin when omitted. */
+  x?: number;
+  y?: number;
+}
+
+export interface SetDevicePropertyParams {
+  nodeId: string;
+  /** Only keys in SAFE_DEVICE_FIELDS are applied; anything else is rejected. */
+  properties: Record<string, string | number | boolean>;
+}
+
+export interface ConnectDevicesParams {
+  sourceNodeId: string;
+  sourcePortId: string;
+  sourceFace?: PortFace;
+  targetNodeId: string;
+  targetPortId: string;
+  targetFace?: PortFace;
+}
+
+export interface GetDeviceParams {
+  nodeId: string;
+}
+
+export interface SearchTemplatesParams {
+  query: string;
+  limit?: number;
+}
+
+export interface DeleteDeviceParams {
+  nodeId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Device-property whitelist. Each safe field maps to the store action that
+// applies it correctly. Fields with port/edge/structural invariants are
+// deliberately ABSENT and rejected (deferred to Ship 2), so the bridge can
+// never corrupt a drawing through a blind merge.
+// ---------------------------------------------------------------------------
+export type SafeFieldKind = "label" | "shortName" | "patch";
+
+export const SAFE_DEVICE_FIELDS: Record<string, SafeFieldKind> = {
+  label: "label",
+  shortName: "shortName",
+  hostname: "patch",
+  color: "patch",
+  headerColor: "patch",
+  manufacturer: "patch",
+  modelNumber: "patch",
+  referenceUrl: "patch",
+  category: "patch",
+  note: "patch",
+  serialNumber: "patch",
+  voltage: "patch",
+  powerDrawW: "patch",
+  powerCapacityW: "patch",
+  thermalBtuh: "patch",
+  poeBudgetW: "patch",
+  poeDrawW: "patch",
+  unitCost: "patch",
+  heightMm: "patch",
+  widthMm: "patch",
+  depthMm: "patch",
+  weightKg: "patch",
+  isSpare: "patch",
+  isVenueProvided: "patch",
+  useShortName: "patch",
+  wrapLabel: "patch",
+};

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure helpers for the MCP bridge — no store, DOM, or socket access, so they are
+ * unit-testable in isolation. The bridge (`src/mcpBridge.ts`) wraps these and
+ * applies their results through the store actions.
+ */
+import { SAFE_DEVICE_FIELDS, type PortFace } from "./protocol";
+
+export interface ClassifiedProperties {
+  /** New device label, if `label` was supplied (apply via updateDeviceLabel). */
+  label?: string;
+  /** New short name, if `shortName` was supplied (apply via updateDeviceShortName). */
+  shortName?: string;
+  /** Remaining safe scalar fields to merge via patchDeviceData. */
+  patch: Record<string, string | number | boolean>;
+  /** Keys that were accepted (across all three buckets above). */
+  applied: string[];
+  /** Keys rejected because they are not in the Ship-1 whitelist. */
+  rejected: string[];
+}
+
+function isScalar(value: unknown): value is string | number | boolean {
+  return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
+}
+
+/** Split a property bag into the correct store-action buckets, dropping any field
+ *  that is not on the safe whitelist OR whose value is not a plain scalar. Input is
+ *  untrusted (it arrives over the bridge), so non-scalar values (objects, arrays,
+ *  null) are rejected rather than persisted. Fields with port/edge/structural
+ *  invariants are never in SAFE_DEVICE_FIELDS, so this can never drive a structural
+ *  mutation. */
+export function classifyDeviceProperties(
+  properties: Record<string, unknown>,
+): ClassifiedProperties {
+  const result: ClassifiedProperties = { patch: {}, applied: [], rejected: [] };
+  for (const [key, value] of Object.entries(properties)) {
+    const kind = SAFE_DEVICE_FIELDS[key];
+    if (!kind || !isScalar(value)) {
+      result.rejected.push(key);
+      continue;
+    }
+    if (kind === "label") result.label = String(value);
+    else if (kind === "shortName") result.shortName = String(value);
+    else result.patch[key] = value;
+    result.applied.push(key);
+  }
+  return result;
+}
+
+export type HandleResolution =
+  | { ok: true; handleId: string }
+  | { ok: false; error: string };
+
+/**
+ * Pick the React Flow handle id for a (portId, face) given the candidate handle
+ * ids the layout produced for that port:
+ *   - 0 candidates -> port not found
+ *   - 1 candidate  -> use it (face ignored; plain input/output port)
+ *   - 2 candidates -> two-sided port; the face selects `${portId}-${face}`
+ */
+export function resolveHandleFromCandidates(
+  candidateHandleIds: string[],
+  portId: string,
+  face: PortFace | undefined,
+): HandleResolution {
+  if (candidateHandleIds.length === 0) {
+    return { ok: false, error: `Port "${portId}" not found.` };
+  }
+  if (candidateHandleIds.length === 1) {
+    return { ok: true, handleId: candidateHandleIds[0] };
+  }
+  const faces = candidateHandleIds
+    .map((h) => (h.startsWith(`${portId}-`) ? h.slice(portId.length + 1) : ""))
+    .filter(Boolean);
+  if (!face) {
+    return { ok: false, error: `Port "${portId}" has two sides; specify face as one of: ${faces.join(", ")}.` };
+  }
+  const wanted = `${portId}-${face}`;
+  if (candidateHandleIds.includes(wanted)) {
+    return { ok: true, handleId: wanted };
+  }
+  return { ok: false, error: `Invalid face "${face}" for port "${portId}". Valid: ${faces.join(", ")}.` };
+}

--- a/src/mcpBridge.ts
+++ b/src/mcpBridge.ts
@@ -1,0 +1,405 @@
+/**
+ * In-app side of the EasySchematic MCP bridge (Beta).
+ *
+ * A small WebSocket *client* that connects to the standalone MCP server
+ * (`mcp-server/`) running on localhost. It receives tool commands from Claude
+ * and executes each by calling the EXISTING store actions — so undo, autosave,
+ * validation and auto-routing all keep working unchanged. It never opens a
+ * listening socket and only connects when the user turns on the Beta setting and
+ * supplies the pairing token.
+ *
+ * Security: the connection is gated by a pairing token (sent in the handshake)
+ * and the server additionally checks the request Origin. Both must pass before
+ * any command runs.
+ */
+import { useEffect } from "react";
+import type { Connection } from "@xyflow/react";
+import { useSchematicStore } from "./store";
+import { getPortAbsolutePositions } from "./snapUtils";
+import { getBundledTemplates, getTemplateById, fetchTemplates } from "./templateApi";
+import {
+  DEFAULT_BRIDGE_PORT,
+  PROTOCOL_VERSION,
+  type CommandType,
+  type BridgeServerMessage,
+  type AddDeviceParams,
+  type SetDevicePropertyParams,
+  type ConnectDevicesParams,
+  type GetDeviceParams,
+  type SearchTemplatesParams,
+  type DeleteDeviceParams,
+  type PortFace,
+} from "./mcp/protocol";
+import { classifyDeviceProperties, resolveHandleFromCandidates } from "./mcp/validation";
+import type { DeviceData, DeviceTemplate, Port, SchematicNode } from "./types";
+
+export type BridgeStatus = "off" | "connecting" | "connected" | "error";
+
+/** Raised inside a command handler to return ok:false with a readable message. */
+class CommandError extends Error {}
+
+function st() {
+  return useSchematicStore.getState();
+}
+
+function setStatus(status: BridgeStatus, detail?: string) {
+  useSchematicStore.setState({ mcpBridgeStatus: status, mcpBridgeStatusDetail: detail });
+}
+
+function deviceNodes(): SchematicNode[] {
+  return st().nodes.filter((n) => n.type === "device");
+}
+
+function requireDevice(nodeId: string): SchematicNode {
+  const node = st().nodes.find((n) => n.id === nodeId);
+  if (!node) throw new CommandError(`No device found with id "${nodeId}".`);
+  if (node.type !== "device") throw new CommandError(`Node "${nodeId}" is not a device.`);
+  return node;
+}
+
+function portSummary(p: Port) {
+  return { id: p.id, label: p.label, direction: p.direction, signalType: p.signalType };
+}
+
+/** The full discoverable set: the live community library (which already has the
+ *  bundled fallback merged as a floor) plus this schematic's custom templates,
+ *  de-duped by key. fetchTemplates() is internally cached, so repeated calls are
+ *  cheap; on a network failure it falls back to the bundled subset. */
+async function allTemplates(): Promise<DeviceTemplate[]> {
+  let library: DeviceTemplate[];
+  try {
+    library = await fetchTemplates();
+  } catch {
+    library = getBundledTemplates();
+  }
+  const merged = new Map<string, DeviceTemplate>();
+  for (const t of [...library, ...st().customTemplates]) {
+    merged.set(t.id ?? t.deviceType, t);
+  }
+  return [...merged.values()];
+}
+
+function resolveTemplate(templateId: string, list: DeviceTemplate[]): DeviceTemplate | undefined {
+  return (
+    getTemplateById(templateId, st().customTemplates) ??
+    list.find((t) => (t.id ?? t.deviceType) === templateId) ??
+    list.find((t) => t.deviceType === templateId)
+  );
+}
+
+/** Resolve a (portId, face) to the React Flow handle id the UI would use, by
+ *  asking the same geometry helper that lays out the node's handles. */
+function resolveHandle(node: SchematicNode, portId: string, face: PortFace | undefined): string {
+  const nodeMap = new Map(st().nodes.map((n) => [n.id, n] as const));
+  const candidates = getPortAbsolutePositions(node, nodeMap)
+    .filter((h) => h.portId === portId)
+    .map((h) => h.handleId);
+  const res = resolveHandleFromCandidates(candidates, portId, face);
+  if (!res.ok) throw new CommandError(res.error);
+  return res.handleId;
+}
+
+// ---------------------------------------------------------------------------
+// Command handlers — each returns a JSON-serializable result or throws CommandError.
+// ---------------------------------------------------------------------------
+const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown | Promise<unknown>> = {
+  get_schematic: () => {
+    const devices = deviceNodes().map((n) => {
+      const d = n.data as DeviceData;
+      return {
+        nodeId: n.id,
+        label: d.label,
+        deviceType: d.deviceType,
+        manufacturer: d.manufacturer,
+        position: n.position,
+        ports: (d.ports ?? []).map(portSummary),
+      };
+    });
+    const connections = st().edges.map((e) => ({
+      id: e.id,
+      source: e.source,
+      sourceHandle: e.sourceHandle,
+      target: e.target,
+      targetHandle: e.targetHandle,
+    }));
+    return {
+      schematicName: st().schematicName,
+      deviceCount: devices.length,
+      connectionCount: connections.length,
+      devices,
+      connections,
+    };
+  },
+
+  list_devices: () =>
+    deviceNodes().map((n) => {
+      const d = n.data as DeviceData;
+      return {
+        nodeId: n.id,
+        label: d.label,
+        deviceType: d.deviceType,
+        manufacturer: d.manufacturer,
+        modelNumber: d.modelNumber,
+        position: n.position,
+      };
+    }),
+
+  get_device: (params) => {
+    const { nodeId } = params as unknown as GetDeviceParams;
+    const node = requireDevice(nodeId);
+    const d = node.data as DeviceData;
+    return {
+      nodeId: node.id,
+      label: d.label,
+      shortName: d.shortName,
+      deviceType: d.deviceType,
+      manufacturer: d.manufacturer,
+      modelNumber: d.modelNumber,
+      position: node.position,
+      ports: (d.ports ?? []).map(portSummary),
+    };
+  },
+
+  search_templates: async (params) => {
+    const { query, limit } = params as unknown as SearchTemplatesParams;
+    const q = (query ?? "").trim().toLowerCase();
+    const list = await allTemplates();
+    const scored = list.filter((t) => {
+      if (!q) return true;
+      const hay = [t.label, t.deviceType, t.manufacturer, t.modelNumber, ...(t.searchTerms ?? [])]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return hay.includes(q);
+    });
+    return scored.slice(0, Math.max(1, Math.min(limit ?? 25, 100))).map((t) => ({
+      templateId: t.id ?? t.deviceType,
+      label: t.label,
+      deviceType: t.deviceType,
+      manufacturer: t.manufacturer,
+      portCount: (t.ports ?? []).length,
+    }));
+  },
+
+  add_device: async (params) => {
+    const { templateId, label, x, y } = params as unknown as AddDeviceParams;
+    if (!templateId) throw new CommandError("templateId is required.");
+    const tpl = resolveTemplate(templateId, await allTemplates());
+    if (!tpl) throw new CommandError(`No template found for "${templateId}". Use search_templates first.`);
+    const position = { x: x ?? 0, y: y ?? 0 };
+    const before = new Set(st().nodes.map((n) => n.id));
+    st().addDevice(tpl, position);
+    const added = st().nodes.find((n) => !before.has(n.id));
+    if (!added) throw new CommandError("Device was not added (no new node appeared).");
+    if (label && label !== tpl.label) st().updateDeviceLabel(added.id, label);
+    return { nodeId: added.id, label: (added.data as DeviceData).label, position };
+  },
+
+  set_device_property: (params) => {
+    const { nodeId, properties } = params as unknown as SetDevicePropertyParams;
+    requireDevice(nodeId);
+    if (!properties || typeof properties !== "object") {
+      throw new CommandError("properties must be an object.");
+    }
+    const { label, shortName, patch, applied, rejected } = classifyDeviceProperties(properties);
+    if (applied.length === 0) {
+      throw new CommandError(
+        `No editable fields. Rejected (not allowed in Beta): ${rejected.join(", ")}.`,
+      );
+    }
+    if (label !== undefined) st().updateDeviceLabel(nodeId, label);
+    if (shortName !== undefined) st().updateDeviceShortName(nodeId, shortName);
+    if (Object.keys(patch).length > 0) st().patchDeviceData(nodeId, patch as Partial<DeviceData>);
+    return { nodeId, applied, rejected };
+  },
+
+  connect_devices: (params) => {
+    const p = params as unknown as ConnectDevicesParams;
+    const sourceNode = requireDevice(p.sourceNodeId);
+    const targetNode = requireDevice(p.targetNodeId);
+    const sourceHandle = resolveHandle(sourceNode, p.sourcePortId, p.sourceFace);
+    const targetHandle = resolveHandle(targetNode, p.targetPortId, p.targetFace);
+    const connection: Connection = {
+      source: p.sourceNodeId,
+      sourceHandle,
+      target: p.targetNodeId,
+      targetHandle,
+    };
+    if (!st().isValidConnection(connection)) {
+      throw new CommandError(
+        `That connection is not valid (incompatible direction/signal, duplicate, or self-connection).`,
+      );
+    }
+    const before = new Set(st().edges.map((e) => e.id));
+    st().onConnect(connection);
+    const edge = st().edges.find((e) => !before.has(e.id));
+    if (!edge) {
+      // isValidConnection passed, but onConnect can still bail into the
+      // incompatible-connection flow (connector/signal needs an adapter, or there
+      // are zero/multiple adapter matches), leaving a pending UI prompt and no
+      // edge. Clear that pending state and report honestly rather than claiming
+      // a connection that never happened.
+      useSchematicStore.setState({ pendingIncompatibleConnection: null });
+      throw new CommandError(
+        "Connection was not created — these ports are incompatible and need an adapter device between them.",
+      );
+    }
+    return { connected: true, edgeId: edge.id, sourceHandle, targetHandle };
+  },
+
+  delete_device: (params) => {
+    const { nodeId } = params as unknown as DeleteDeviceParams;
+    requireDevice(nodeId);
+    st().deleteNode(nodeId);
+    return { deleted: true, nodeId };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Connection controller — a singleton driven by the useMcpBridge() hook.
+// ---------------------------------------------------------------------------
+class BridgeController {
+  private ws: WebSocket | null = null;
+  private enabled = false;
+  private token = "";
+  private port = DEFAULT_BRIDGE_PORT;
+  private clientId =
+    typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `tab-${Date.now()}`;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private backoffMs = 1000;
+  /** Set when pairing was refused (bad token / superseded) so we stop retrying. */
+  private halted = false;
+
+  /** (Re)start with the latest settings. Idempotent for unchanged inputs. */
+  start(token: string, port: number) {
+    if (this.enabled && this.token === token && this.port === port && (this.ws || this.reconnectTimer)) {
+      return; // already running with the same config (StrictMode-safe)
+    }
+    this.stop();
+    this.enabled = true;
+    this.token = token;
+    this.port = port || DEFAULT_BRIDGE_PORT;
+    this.halted = false;
+    this.backoffMs = 1000;
+    this.connect();
+  }
+
+  stop() {
+    this.enabled = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      this.ws.onopen = this.ws.onmessage = this.ws.onclose = this.ws.onerror = null;
+      try {
+        this.ws.close();
+      } catch {
+        /* ignore */
+      }
+      this.ws = null;
+    }
+    setStatus("off");
+  }
+
+  private scheduleReconnect() {
+    if (!this.enabled || this.halted) return;
+    this.reconnectTimer = setTimeout(() => this.connect(), this.backoffMs);
+    this.backoffMs = Math.min(this.backoffMs * 2, 15000);
+  }
+
+  private connect() {
+    if (!this.enabled || this.halted) return;
+    setStatus("connecting");
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(`ws://127.0.0.1:${this.port}`);
+    } catch {
+      setStatus("error", "Could not open a connection.");
+      this.scheduleReconnect();
+      return;
+    }
+    this.ws = ws;
+
+    ws.onopen = () => {
+      ws.send(
+        JSON.stringify({
+          type: "hello",
+          token: this.token,
+          protocolVersion: PROTOCOL_VERSION,
+          clientId: this.clientId,
+          schematicName: st().schematicName,
+        }),
+      );
+    };
+
+    ws.onmessage = (ev) => this.onMessage(ev);
+
+    ws.onerror = () => {
+      setStatus("error", "Connection error — is the MCP server running?");
+    };
+
+    ws.onclose = () => {
+      if (this.ws === ws) this.ws = null;
+      if (this.enabled && !this.halted) {
+        setStatus("connecting", "Reconnecting…");
+        this.scheduleReconnect();
+      }
+    };
+  }
+
+  private async onMessage(ev: MessageEvent) {
+    let msg: BridgeServerMessage;
+    try {
+      msg = JSON.parse(typeof ev.data === "string" ? ev.data : "");
+    } catch {
+      return;
+    }
+    if (msg.type === "hello_ack") {
+      if (msg.ok) {
+        this.backoffMs = 1000;
+        setStatus("connected");
+      } else {
+        this.halted = true;
+        setStatus("error", msg.reason ?? "Pairing refused.");
+      }
+      return;
+    }
+    if (msg.type === "superseded") {
+      this.halted = true;
+      setStatus("error", msg.reason ?? "Another tab took the AI connection.");
+      return;
+    }
+    if (msg.type === "command") {
+      const { requestId, command, params } = msg;
+      const reply = (ok: boolean, payload: { result?: unknown; error?: string }) =>
+        this.ws?.send(JSON.stringify({ type: "response", requestId, ok, ...payload }));
+      const handler = handlers[command];
+      if (!handler) {
+        reply(false, { error: `Unknown command "${command}".` });
+        return;
+      }
+      try {
+        const result = await handler(params ?? {});
+        reply(true, { result });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        reply(false, { error: message });
+      }
+    }
+  }
+}
+
+export const mcpBridge = new BridgeController();
+
+/** Mount once (in App). Starts/stops the bridge as the Beta setting changes. */
+export function useMcpBridge() {
+  const enabled = useSchematicStore((s) => s.mcpBridgeEnabled);
+  const token = useSchematicStore((s) => s.mcpBridgeToken);
+  const port = useSchematicStore((s) => s.mcpBridgePort);
+  useEffect(() => {
+    if (enabled && token) mcpBridge.start(token, port);
+    else mcpBridge.stop();
+    return () => mcpBridge.stop();
+  }, [enabled, token, port]);
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -56,6 +56,7 @@ import { DEVICE_TEMPLATES } from "./deviceLibrary";
 import { createDefaultLayout } from "./titleBlockLayout";
 import { sanitizeNoteHtml } from "./sanitizeHtml";
 import { getTemplateById } from "./templateApi";
+import { DEFAULT_BRIDGE_PORT } from "./mcp/protocol";
 import { syncDeviceWithTemplate, type SyncResult } from "./templateSync";
 import { chooseNewHandleSuffix, type SwapPlan, type NewPortRef } from "./deviceSwap";
 import { getSignalColorOverrides, applySignalColors, loadSignalColors, saveSignalColors } from "./signalColors";
@@ -96,6 +97,9 @@ const TEMPLATES_KEY = "easyschematic-custom-templates";
 const TEMPLATE_META_KEY = "easyschematic-custom-template-meta";
 const CATEGORY_ORDER_KEY = "easyschematic-category-order";
 const MINIMAP_PREF_KEY = "easyschematic-show-minimap";
+const MCP_ENABLED_KEY = "easyschematic-mcp-enabled";
+const MCP_TOKEN_KEY = "easyschematic-mcp-token";
+const MCP_PORT_KEY = "easyschematic-mcp-port";
 
 /** Minimap visibility is an editor preference (not document data), persisted to
  *  localStorage and shared across schematics/sessions. Default visible. (#210) */
@@ -104,6 +108,31 @@ function loadShowMinimap(): boolean {
     return localStorage.getItem(MINIMAP_PREF_KEY) !== "0";
   } catch {
     return true;
+  }
+}
+
+/** MCP bridge (Beta) editor preferences — persisted to localStorage, not the
+ *  schematic file. Off by default; the bridge only connects once enabled. */
+function loadMcpEnabled(): boolean {
+  try {
+    return localStorage.getItem(MCP_ENABLED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+function loadMcpToken(): string {
+  try {
+    return localStorage.getItem(MCP_TOKEN_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+function loadMcpPort(): number {
+  try {
+    const raw = Number(localStorage.getItem(MCP_PORT_KEY));
+    return Number.isInteger(raw) && raw > 0 ? raw : DEFAULT_BRIDGE_PORT;
+  } catch {
+    return DEFAULT_BRIDGE_PORT;
   }
 }
 
@@ -578,6 +607,17 @@ interface SchematicState {
   /** Canvas minimap visibility — editor preference, persisted to localStorage. (#210) */
   showMinimap: boolean;
   setShowMinimap: (show: boolean) => void;
+
+  /** MCP bridge (Beta): lets Claude read/edit the schematic live via the local
+   *  MCP server. Persisted editor prefs; status is ephemeral, set by the bridge. */
+  mcpBridgeEnabled: boolean;
+  mcpBridgeToken: string;
+  mcpBridgePort: number;
+  mcpBridgeStatus: "off" | "connecting" | "connected" | "error";
+  mcpBridgeStatusDetail?: string;
+  setMcpBridgeEnabled: (enabled: boolean) => void;
+  setMcpBridgeToken: (token: string) => void;
+  setMcpBridgePort: (port: number) => void;
 
   /** Rack: show connector-level face-plate detail (default off; advanced) */
   showFacePlateDetail: boolean;
@@ -1288,6 +1328,11 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
   status: undefined,
   showLineJumps: true,
   showMinimap: loadShowMinimap(),
+  mcpBridgeEnabled: loadMcpEnabled(),
+  mcpBridgeToken: loadMcpToken(),
+  mcpBridgePort: loadMcpPort(),
+  mcpBridgeStatus: "off",
+  mcpBridgeStatusDetail: undefined,
   showFacePlateDetail: false,
   showConnectionLabels: true,
   showCableIdLabels: true,
@@ -3781,6 +3826,19 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
     // Persisted to localStorage (editor preference), not the schematic file. (#210)
     try { localStorage.setItem(MINIMAP_PREF_KEY, show ? "1" : "0"); } catch { /* ignore */ }
     set({ showMinimap: show });
+  },
+
+  setMcpBridgeEnabled: (enabled) => {
+    try { localStorage.setItem(MCP_ENABLED_KEY, enabled ? "1" : "0"); } catch { /* ignore */ }
+    set({ mcpBridgeEnabled: enabled });
+  },
+  setMcpBridgeToken: (token) => {
+    try { localStorage.setItem(MCP_TOKEN_KEY, token); } catch { /* ignore */ }
+    set({ mcpBridgeToken: token });
+  },
+  setMcpBridgePort: (port) => {
+    try { localStorage.setItem(MCP_PORT_KEY, String(port)); } catch { /* ignore */ }
+    set({ mcpBridgePort: port });
   },
 
   setShowFacePlateDetail: (show) => {


### PR DESCRIPTION
## What

Adds an **opt-in, Beta** [Model Context Protocol](https://modelcontextprotocol.io) bridge so an AI assistant (e.g. Claude) can **read and edit a schematic live in the running editor** — add a device, set safe properties, connect devices, etc. — with the user watching every change happen on the canvas.

This is the **first of a planned series**. I have follow-on slices already built on my fork (editing/layout, batch ops, rooms, notes, modular-chassis slots, rack elevations) and would send them as separate PRs once this lands. **Happy to adjust scope, naming, or structure to your preferences before I do** — this PR is also meant to gauge whether you'd want the feature at all.

## How it works

```
AI assistant (MCP client) ──stdio──▶ easyschematic-mcp ──ws://127.0.0.1──▶ EasySchematic tab
```

- **`mcp-server/`** — a small, self-contained Node package (its own `package.json`/`tsconfig`; **not** built by the app or CI). An MCP stdio server that also hosts a localhost WebSocket the editor dials into.
- **In-app bridge** (`src/mcpBridge.ts`, mounted once in `App.tsx`) — the app is the WebSocket *client*. Commands run through **existing store actions** (`addDevice`, `patchDeviceData`, `onConnect`, `isValidConnection`, `deleteNode`, …), so undo, autosave, validation and auto-routing all keep working.
- **Shared wire protocol** (`src/mcp/protocol.ts`) is the single source of truth; the server imports a generated copy so the two sides can't drift.
- A new **"AI (Beta)"** tab in Preferences (off by default) holds the toggle, pairing token and port; docs page added.

## Security (the reason it's safe)

- **Off by default.** The WebSocket binds to **`127.0.0.1` only** — never the public network.
- A tab must pass an **Origin check** (localhost allowed by default; self-hosters add `EASYSCHEMATIC_MCP_ORIGINS`) **and** a **pairing token** (constant-time compare) before any command runs. One active tab at a time.
- **`set_device_property` is whitelisted to safe scalar fields** — structural edits (ports/slots) are rejected, so the bridge can't corrupt a drawing.

## Scope of this PR (8 core tools)

`get_schematic`, `list_devices`, `get_device`, `search_templates`, `add_device`, `set_device_property`, `connect_devices`, `delete_device`.

## Notes

- **Additive** — no schema or version bump (no saved-file format change).
- Includes unit tests (`mcp-server` origin/token checks; pure validation helpers in `src/mcp/validation.ts`).
- The `mcp-server` package is built/tested **separately** (`cd mcp-server && npm i && npm run build && npm test`), not by the app or CI.
- Known limitation (documented): `connect_devices` delegates auto-adapter discovery to the app's `onConnect`, which only searches bundled + custom templates (same limit the UI has) — `add_device` the adapter first, then connect.