### PR TITLE
Escape user email before HTML interpolation in auth pages (XSS fix)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -199,7 +199,7 @@ app.post("/auth/login", async (c) => {
       ].join("\n"),
       html: `<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:480px;margin:0 auto;padding:24px">
 <h2 style="font-size:18px;color:#0f172a;margin:0 0 16px">Log in to EasySchematic</h2>
-<p style="color:#334155;font-size:14px;line-height:1.6;margin:0 0 8px">We received a login request for <strong>${email}</strong>.</p>
+<p style="color:#334155;font-size:14px;line-height:1.6;margin:0 0 8px">We received a login request for <strong>${escapeHtml(email)}</strong>.</p>
 <p style="color:#334155;font-size:14px;line-height:1.6;margin:0 0 24px">Click the button below to sign in:</p>
 <p style="margin:0 0 24px"><a href="${verifyUrl}" style="display:inline-block;padding:12px 24px;background:#1e293b;color:white;text-decoration:none;border-radius:8px;font-weight:600;">Log in to EasySchematic</a></p>
 <p style="color:#64748b;font-size:13px;line-height:1.6;margin:0 0 4px">Or copy and paste this URL into your browser:</p>
@@ -283,7 +283,7 @@ app.get("/auth/verify", async (c) => {
     : "/auth/verify";
 
   return c.html(authPage("Confirm Login", `<h1>Confirm Login</h1>
-    <p>Click below to complete your login as <strong>${link.email}</strong>.</p>
+    <p>Click below to complete your login as <strong>${escapeHtml(link.email)}</strong>.</p>
     <form method="POST" action="${formAction}">
       <input type="hidden" name="token" value="${token}">
       <button type="submit" class="btn">Complete Login</button>


### PR DESCRIPTION
## Summary

The passwordless-login flow interpolates the user-supplied email into HTML **without escaping** in two spots in `api/src/index.ts`. Since `POST /auth/login` only validates the email with `email.includes("@")`, a near-arbitrary string is accepted and stored verbatim in `magic_links.email`, then rendered as raw HTML:

- **`GET /auth/verify` "Confirm Login" page** (returned via `c.html()`, rendered on the `api.easyschematic.live` origin). An email such as `<img src=x onerror=…>@x` results in **script execution on the API origin** when the recipient opens their own magic link. This is the higher-severity sink because it runs in a real browser context on your API domain.
- **The outbound Resend login-email HTML body** — same untrusted value; lower impact (lands only in the requester's own inbox, and mail clients sandbox HTML), but the same injection class.

## Fix

Wrap both interpolations with the **existing** `escapeHtml()` helper already defined in the same file (`api/src/index.ts`, escapes `& < > "` and already used elsewhere for the submission-notification email). This is output-encoding only — no change to the login flow's behaviour.

```diff
-We received a login request for <strong>${email}</strong>.
+We received a login request for <strong>${escapeHtml(email)}</strong>.
```
```diff
-<p>Click below to complete your login as <strong>${link.email}</strong>.</p>
+<p>Click below to complete your login as <strong>${escapeHtml(link.email)}</strong>.</p>
```

## Notes / scope

- Both sinks are HTML text-node contexts, so escaping `& < > "` is sufficient.
- I intentionally left the `includes("@")` input validation as-is — escaping at the output is the correct and complete fix for the XSS; tightening the email format is a separate, optional defense-in-depth change.
- Other interpolations on these pages were checked and are not user-controlled (`token` is a server-generated UUID; the return-to origin is constrained by an allow-list).
- No tests added: the `api/` package currently has no test harness, so this is a minimal output-encoding change reusing an already-shipped helper.

Happy to adjust framing or add validation hardening if you'd prefer that in the same PR.