### PR TITLE
Expand the MCP bridge tool surface (Beta): editing, batch, rooms, notes, slots, racks

### DIFF
--- a/docs/src/pages/AiAssistant.tsx
+++ b/docs/src/pages/AiAssistant.tsx
@@ -156,12 +156,14 @@ node dist/index.js`}</code>
           shelves and blanking panels, are still added in the editor.
         </li>
         <li>
-          <strong>Work in batches</strong> — add many devices, or make many
-          connections, in a single request. Each item is handled on its own:
-          if one fails, the rest still go through, and the assistant gets back a
-          per-item list of what succeeded and what didn't. Undo works just like
-          doing each action one at a time (so a batch takes a few presses of undo
-          to fully reverse, not one).
+          <strong>Work in batches</strong> — add many devices, make many
+          connections, install many chassis cards, or mount many devices into racks,
+          each in a single request. Each item is handled on its own: if one fails, the
+          rest still go through, and the assistant gets back a per-item list of what
+          succeeded and what didn't. Items are applied in order, so an earlier one can
+          affect a later one (for example, filling a slot or a rack position the next
+          item wanted). Undo works just like doing each action one at a time (so a
+          batch takes a few presses of undo to fully reverse, not one).
         </li>
       </ul>
 

--- a/docs/src/pages/AiAssistant.tsx
+++ b/docs/src/pages/AiAssistant.tsx
@@ -116,6 +116,14 @@ node dist/index.js`}</code>
         <li>
           <strong>Delete a device.</strong>
         </li>
+        <li>
+          <strong>Work in batches</strong> — add many devices, or make many
+          connections, in a single request. Each item is handled on its own:
+          if one fails, the rest still go through, and the assistant gets back a
+          per-item list of what succeeded and what didn't. Undo works just like
+          doing each action one at a time (so a batch takes a few presses of undo
+          to fully reverse, not one).
+        </li>
       </ul>
 
       <div

--- a/docs/src/pages/AiAssistant.tsx
+++ b/docs/src/pages/AiAssistant.tsx
@@ -105,6 +105,15 @@ node dist/index.js`}</code>
           connection is validated before it is made.
         </li>
         <li>
+          <strong>Move a device</strong> to a new position. The device stays in its
+          current room or rack — this does not move it into or out of one.
+        </li>
+        <li>
+          <strong>Remove a single connection.</strong> Stubbed connections can't be
+          removed this way yet — delete one of their devices, or remove them in the
+          editor.
+        </li>
+        <li>
           <strong>Delete a device.</strong>
         </li>
       </ul>

--- a/docs/src/pages/AiAssistant.tsx
+++ b/docs/src/pages/AiAssistant.tsx
@@ -152,8 +152,13 @@ node dist/index.js`}</code>
           remove a device from a rack. It won't stack two devices in the same space,
           place a device that's already in another rack, or use the rear of a 2-post
           frame. Full- and half-rack gear is placed automatically from each device's
-          physical size; very small gear that needs a shelf, and rack accessories like
-          shelves and blanking panels, are still added in the editor.
+          physical size; very small gear that needs a shelf is dropped onto a shelf the
+          assistant adds for it, and removing that device later clears the shelf too —
+          unless you've made the shelf your own (renamed, resized, moved it, or put
+          another device on it), in which case the assistant leaves it alone. Removing
+          the device any other way (deleting it, or unracking it in the editor) keeps the
+          empty shelf, just as the editor always has. Other rack accessories like blanking
+          panels are still added in the editor.
         </li>
         <li>
           <strong>Work in batches</strong> — add many devices, make many

--- a/docs/src/pages/AiAssistant.tsx
+++ b/docs/src/pages/AiAssistant.tsx
@@ -121,6 +121,12 @@ node dist/index.js`}</code>
           device instead.
         </li>
         <li>
+          <strong>Add a note</strong> — a text note card placed on the canvas to
+          annotate or explain the schematic. The text is shown literally and line
+          breaks are kept. Notes can't yet be listed, edited, or deleted through the
+          assistant — do that in the editor.
+        </li>
+        <li>
           <strong>Remove a single connection.</strong> Stubbed connections can't be
           removed this way yet — delete one of their devices, or remove them in the
           editor.

--- a/docs/src/pages/AiAssistant.tsx
+++ b/docs/src/pages/AiAssistant.tsx
@@ -109,6 +109,18 @@ node dist/index.js`}</code>
           current room or rack — this does not move it into or out of one.
         </li>
         <li>
+          <strong>Create a room</strong> — a labelled container devices can sit
+          inside. Size is optional (defaults to 400×300). Any devices already inside
+          the new room's outline are pulled into it.
+        </li>
+        <li>
+          <strong>Place a device in a room.</strong> The position is given relative
+          to the room's top-left corner. If the spot is outside the room the request
+          is refused and nothing changes, so a device is never reported as placed
+          when it isn't. To nudge a device that is already in a room, use move a
+          device instead.
+        </li>
+        <li>
           <strong>Remove a single connection.</strong> Stubbed connections can't be
           removed this way yet — delete one of their devices, or remove them in the
           editor.

--- a/docs/src/pages/AiAssistant.tsx
+++ b/docs/src/pages/AiAssistant.tsx
@@ -86,8 +86,9 @@ node dist/index.js`}</code>
 
       <ul>
         <li>
-          <strong>Read</strong> — view the schematic, list devices, inspect one
-          device, and search the device library.
+          <strong>Read</strong> — view the schematic (its devices, connections,
+          rooms and notes), list devices, inspect one device, and search the device
+          library.
         </li>
         <li>
           <strong>Add a device</strong> from a library template.
@@ -121,10 +122,12 @@ node dist/index.js`}</code>
           device instead.
         </li>
         <li>
-          <strong>Add a note</strong> — a text note card placed on the canvas to
-          annotate or explain the schematic. The text is shown literally and line
-          breaks are kept. Notes can't yet be listed, edited, or deleted through the
-          assistant — do that in the editor.
+          <strong>Add, edit, and delete notes</strong> — text note cards placed on
+          the canvas to annotate or explain the schematic. The text is shown literally
+          and line breaks are kept. Existing notes show up when the assistant reads the
+          schematic, so it can rewrite a note's text or remove it. Editing replaces the
+          whole note, so a note you formatted in the editor (bold, lists) becomes plain
+          text when the assistant rewrites it.
         </li>
         <li>
           <strong>Remove a single connection.</strong> Stubbed connections can't be

--- a/docs/src/pages/AiAssistant.tsx
+++ b/docs/src/pages/AiAssistant.tsx
@@ -135,6 +135,14 @@ node dist/index.js`}</code>
           <strong>Delete a device.</strong>
         </li>
         <li>
+          <strong>Fill a modular chassis</strong> — for a device with slots, the
+          assistant can see its slots (via the device details), list the expansion
+          cards that fit a slot, install a card into an empty slot, and remove a card
+          to empty a slot. A card is only installed when its slot family matches the
+          slot's, and installing never silently replaces a card already in a slot.
+          (Defining new slots is still done in the editor.)
+        </li>
+        <li>
           <strong>Work in batches</strong> — add many devices, or make many
           connections, in a single request. Each item is handled on its own:
           if one fails, the rest still go through, and the assistant gets back a

--- a/docs/src/pages/AiAssistant.tsx
+++ b/docs/src/pages/AiAssistant.tsx
@@ -143,6 +143,16 @@ node dist/index.js`}</code>
           (Defining new slots is still done in the editor.)
         </li>
         <li>
+          <strong>Build a rack elevation</strong> — the assistant can see your rack
+          elevations, create a rack (it makes a rack-elevation page if you don't have
+          one), mount a device into a rack at a given U position (front or rear), and
+          remove a device from a rack. It won't stack two devices in the same space,
+          place a device that's already in another rack, or use the rear of a 2-post
+          frame. Full- and half-rack gear is placed automatically from each device's
+          physical size; very small gear that needs a shelf, and rack accessories like
+          shelves and blanking panels, are still added in the editor.
+        </li>
+        <li>
           <strong>Work in batches</strong> — add many devices, or make many
           connections, in a single request. Each item is handled on its own:
           if one fails, the rest still go through, and the assistant gets back a

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -5,8 +5,8 @@ live** in your running EasySchematic editor. It speaks [MCP](https://modelcontex
 to the assistant over stdio, and connects to the editor over a localhost WebSocket.
 
 > Beta — only a core set of actions is supported: read the schematic, search the
-> device library, add a device, set safe device properties, connect devices, and
-> delete a device.
+> device library, add a device, set safe device properties, connect devices,
+> move a device, remove a single connection, and delete a device.
 
 ## How it fits together
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -6,7 +6,8 @@ to the assistant over stdio, and connects to the editor over a localhost WebSock
 
 > Beta — only a core set of actions is supported: read the schematic, search the
 > device library, add a device, set safe device properties, connect devices,
-> move a device, remove a single connection, and delete a device.
+> move a device, remove a single connection, delete a device, and batch versions
+> for adding many devices or making many connections at once.
 
 ## How it fits together
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -4,10 +4,12 @@ A small local program that lets an AI assistant (Claude) **read and edit a schem
 live** in your running EasySchematic editor. It speaks [MCP](https://modelcontextprotocol.io)
 to the assistant over stdio, and connects to the editor over a localhost WebSocket.
 
-> Beta — only a core set of actions is supported: read the schematic, search the
-> device library, add a device, set safe device properties, connect devices,
-> move a device, remove a single connection, delete a device, and batch versions
-> for adding many devices or making many connections at once.
+> Beta — supported actions: read the schematic, search the device library, add and
+> delete devices, set safe device properties, connect and disconnect devices, move a
+> device, group devices into rooms, add/edit/delete text notes, fit expansion cards
+> into modular-chassis slots, and build rack elevations (create racks, mount devices).
+> Adding devices, making connections, installing cards and mounting devices in racks
+> each have a batch version for doing many at once.
 
 ## How it fits together
 
@@ -65,6 +67,27 @@ claude mcp add easyschematic -- node /absolute/path/to/EasySchematic/mcp-server/
 
 Then ask Claude things like *“search for a 4K display, add it, and connect the
 laptop's HDMI output to it.”*
+
+## Playbooks & instructions
+
+The server also ships **companion guidance** so any paired client (Claude Desktop,
+claude.ai, Claude Code) drives the schematic the right way without you spelling out
+each step:
+
+- **Server instructions** — a short always-on overview (call `get_schematic` first,
+  `search_templates` before adding, prefer the batch tools, re-read `get_device`
+  after structural changes, use AV terms with the user) that clients surface at
+  connect time.
+- **Prompts** — three named, step-by-step playbooks the user can pick from the
+  client's prompt menu, each taking an optional plain-words argument:
+
+  | Prompt | Argument | What it walks through |
+  |--------|----------|------------------------|
+  | `build-schematic` | `brief` | Lay out and wire a system: `get_schematic` → `search_templates` → `add_devices` → rooms → `connect_devices_batch`. |
+  | `rack-elevation` | `rack` | Build and populate a rack: `list_racks` → `create_rack` → `place_device_in_rack_batch`. |
+  | `modular-chassis` | `chassis` | Fit cards into a chassis: `get_device` → `list_slot_cards` → `install_card_batch`. |
+
+The text lives in `src/prompts.ts`.
 
 ## Develop
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -12,9 +12,15 @@
 import { randomBytes } from "node:crypto";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListPromptsRequestSchema,
+  GetPromptRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
 import { AppBridge } from "./bridge.js";
 import { TOOLS } from "./tools.js";
+import { PROMPTS, getPrompt, SERVER_INSTRUCTIONS } from "./prompts.js";
 import { DEFAULT_BRIDGE_PORT } from "./protocol.generated.js";
 
 const log = (msg: string) => process.stderr.write(`[easyschematic-mcp] ${msg}\n`);
@@ -35,9 +41,18 @@ log(`Pairing token: ${token}`);
 log("Paste this token into EasySchematic → Preferences → AI (Beta), then turn the toggle on.");
 log("");
 
-const server = new Server({ name: "easyschematic", version: "0.1.0" }, { capabilities: { tools: {} } });
+const server = new Server(
+  { name: "easyschematic", version: "0.1.0" },
+  { capabilities: { tools: {}, prompts: {} }, instructions: SERVER_INSTRUCTIONS },
+);
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(ListPromptsRequestSchema, async () => ({ prompts: PROMPTS }));
+
+server.setRequestHandler(GetPromptRequestSchema, async (req) =>
+  getPrompt(req.params.name, req.params.arguments),
+);
 
 server.setRequestHandler(CallToolRequestSchema, async (req) => {
   const { name, arguments: args } = req.params;

--- a/mcp-server/src/prompts.test.ts
+++ b/mcp-server/src/prompts.test.ts
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import { PROMPTS, getPrompt, SERVER_INSTRUCTIONS } from "./prompts.js";
+
+test("PROMPTS: exposes the three named playbooks", () => {
+  assert.deepEqual(
+    PROMPTS.map((p) => p.name).sort(),
+    ["build-schematic", "modular-chassis", "rack-elevation"],
+  );
+  // Every prompt the list advertises must be resolvable by getPrompt.
+  for (const p of PROMPTS) {
+    assert.ok(getPrompt(p.name).messages.length > 0);
+  }
+});
+
+test("getPrompt: a supplied argument is woven into the message", () => {
+  const result = getPrompt("build-schematic", { brief: "huddle room with one display" });
+  const text = result.messages[0].content.type === "text" ? result.messages[0].content.text : "";
+  assert.match(text, /get_schematic/); // the playbook body is present
+  assert.match(text, /huddle room with one display/); // the user's brief is appended
+});
+
+test("getPrompt: missing argument falls back to a guiding instruction", () => {
+  const text = getPrompt("modular-chassis").messages[0].content;
+  assert.equal(text.type, "text");
+  if (text.type === "text") assert.match(text.text, /ask the user which one to configure/);
+});
+
+test("getPrompt: an unknown name throws an MCP InvalidParams error", () => {
+  assert.throws(
+    () => getPrompt("no-such-prompt"),
+    (err) => err instanceof McpError && err.code === ErrorCode.InvalidParams,
+  );
+});
+
+test("SERVER_INSTRUCTIONS: names the three playbooks", () => {
+  for (const name of ["build-schematic", "rack-elevation", "modular-chassis"]) {
+    assert.ok(SERVER_INSTRUCTIONS.includes(name));
+  }
+});

--- a/mcp-server/src/prompts.ts
+++ b/mcp-server/src/prompts.ts
@@ -1,0 +1,117 @@
+/**
+ * Companion guidance for the EasySchematic MCP server.
+ *
+ * Two things ship here, both available to ANY paired MCP client (Claude Desktop,
+ * claude.ai, Claude Code) — not just Claude Code:
+ *   - SERVER_INSTRUCTIONS: a short always-on overview surfaced at initialize time.
+ *   - PROMPTS / getPrompt: three named, parameterized playbooks for the common
+ *     multi-step jobs, so the assistant follows the right tool order instead of
+ *     rediscovering it each time.
+ *
+ * The playbooks reference the real tool names and stay inside their documented
+ * contracts (see tools.ts). User-facing text uses AV terms: Device, Connection, Port.
+ */
+import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
+import type { GetPromptResult, Prompt } from "@modelcontextprotocol/sdk/types.js";
+
+export const SERVER_INSTRUCTIONS = `EasySchematic lets you read and edit an AV signal-flow schematic live in the user's editor. The boxes are Devices, the links between their Ports are Connections — always use those AV terms with the user (never node/edge/handle).
+
+Golden rules:
+- Call get_schematic first to see what already exists before you change anything.
+- Use search_templates to get a templateId before adding a Device — never invent ids.
+- Prefer the batch tools (add_devices, connect_devices_batch, install_card_batch, place_device_in_rack_batch) over repeated single calls; each reports per-item success so you can retry only what failed.
+- Re-read get_device after a structural change (e.g. installing a card) before wiring the new Ports.
+
+Three prompts hold step-by-step playbooks: "build-schematic" (lay out and wire a system), "rack-elevation" (build and populate a rack), and "modular-chassis" (fit cards into a chassis).`;
+
+/** Definitions returned by the prompts/list handler. */
+export const PROMPTS: Prompt[] = [
+  {
+    name: "build-schematic",
+    description: "Playbook for laying out and wiring an AV system on the schematic canvas (get_schematic → search_templates → add_devices → rooms → connect_devices_batch).",
+    arguments: [
+      { name: "brief", description: "What to build, in plain words (e.g. 'a huddle room: laptop to a 4K display via a switcher').", required: false },
+    ],
+  },
+  {
+    name: "rack-elevation",
+    description: "Playbook for creating and populating an equipment rack elevation (list_racks → create_rack → place_device_in_rack_batch).",
+    arguments: [
+      { name: "rack", description: "What rack to build and what to mount in it (e.g. 'a 24U rack with the amp, switcher and matrix').", required: false },
+    ],
+  },
+  {
+    name: "modular-chassis",
+    description: "Playbook for fitting expansion cards into a modular device's slots (get_device → list_slot_cards → install_card_batch).",
+    arguments: [
+      { name: "chassis", description: "Which chassis to configure and which cards to fit (e.g. 'fill the DM matrix with 4 HDMI input cards').", required: false },
+    ],
+  },
+];
+
+const BUILD_SCHEMATIC = `You are building or extending an AV signal-flow schematic in EasySchematic through the live MCP bridge. Work in this order:
+
+1. Call get_schematic FIRST to see the Devices, Connections, rooms and notes that already exist. Never assume an empty canvas.
+2. Find each Device you need with search_templates and use the templateId it returns — never invent a templateId.
+3. Add Devices with add_devices (the batch tool), not repeated add_device calls. Lay them out left-to-right by signal flow: sources and inputs on the left, switchers/processors in the middle, displays and outputs on the right.
+4. If the brief names rooms or areas, create them with create_room BEFORE placing Devices, then place Devices with place_device_in_room. Creating a room on top of Devices that already exist absorbs them and makes their coordinates room-relative — if that happens, call get_schematic again before reusing any old position.
+5. Make Connections with connect_devices_batch. For two-sided Ports give the face: bidirectional Ports use "in"/"out", passthrough Ports use "rear"/"front"; plain Ports need no face. Connections are validated, so read the per-item results and retry only the failures.
+6. After any structural change that adds Ports (e.g. installing a card) re-read get_device before wiring the new Ports.
+7. In anything you say to the user, use the AV terms Device, Connection and Port.`;
+
+const RACK_ELEVATION = `You are creating or populating an equipment rack elevation in EasySchematic through the live MCP bridge. Rack elevations are a separate view from the schematic canvas. Work in this order:
+
+1. Call list_racks FIRST to see existing rack-elevation pages, racks and placements, and to get the pageId / rackId / placementId values the other rack tools need.
+2. Create a rack with create_rack. Omit pageId to start a new rack-elevation page; pass an existing pageId to add the rack to one. Height (U) and depth (mm) are clamped to the editor's ranges.
+3. A Device must already exist on the schematic before it can be mounted — add it there first if needed. Mount existing Devices with place_device_in_rack_batch rather than one at a time.
+4. uPosition is 1-based from the bottom of the rack. Batch placements apply in array order and consume the U span / half-rack side they land on, so order them so they do not overlap, and put heavy or deep gear low.
+5. A Device's height in U is inferred from its dimensions; half-rack gear is auto-placed on a free side, and gear too small to rack-mount is put on an auto-created 1U shelf (the response carries that shelfId).`;
+
+const MODULAR_CHASSIS = `You are configuring a modular Device — a chassis with card slots — in EasySchematic through the live MCP bridge. Work in this order:
+
+1. Call get_device on the chassis to read its slots (each slot has an id and a slot family).
+2. For an empty slot, call list_slot_cards(deviceId, slotId) to get compatible card templateIds. If the full community library has not loaded this session, call search_templates once first so live-library cards are included.
+3. A card's slot family must match the slot's, or the install is refused. A filled slot is never silently overwritten — call remove_card first if you mean to replace one.
+4. Install with install_card_batch rather than one card at a time. Items apply in array order, so an earlier install that opens sub-slots can make a later install into one of them valid.
+5. Installing a card adds Ports to the chassis. Re-read get_device after installs to pick up the new Port ids before you connect them.`;
+
+const PLAYBOOKS: Record<string, { body: string; argName: string; noArgFallback: string }> = {
+  "build-schematic": {
+    body: BUILD_SCHEMATIC,
+    argName: "brief",
+    noArgFallback: "No brief was supplied — summarise the current schematic with get_schematic and ask the user what they want to build or change.",
+  },
+  "rack-elevation": {
+    body: RACK_ELEVATION,
+    argName: "rack",
+    noArgFallback: "No rack was described — call list_racks and ask the user which rack to build or what to mount.",
+  },
+  "modular-chassis": {
+    body: MODULAR_CHASSIS,
+    argName: "chassis",
+    noArgFallback: "No chassis was named — list the modular Devices with get_schematic / get_device and ask the user which one to configure.",
+  },
+};
+
+/**
+ * Resolve a named playbook into prompt messages. The user's free-text argument, if
+ * given, is appended as a second line so the assistant has the concrete task in hand.
+ * Throws an MCP InvalidParams error for an unknown prompt name.
+ */
+export function getPrompt(name: string, args?: Record<string, string>): GetPromptResult {
+  const playbook = PLAYBOOKS[name];
+  if (!playbook) {
+    throw new McpError(ErrorCode.InvalidParams, `Unknown prompt: ${name}`);
+  }
+  const detail = args?.[playbook.argName]?.trim();
+  const tail = detail ? `The user's request: ${detail}` : playbook.noArgFallback;
+  return {
+    description: PROMPTS.find((p) => p.name === name)?.description,
+    messages: [
+      {
+        role: "user",
+        content: { type: "text", text: `${playbook.body}\n\n${tail}` },
+      },
+    ],
+  };
+}

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,8 +1,9 @@
 /**
  * MCP tool catalog: the Ship-1 "working core" tools, the Ship-2 "editing & layout"
  * tools (move_device, delete_connection), the Ship-3 "batch" tools (add_devices,
- * connect_devices_batch), and the Ship-4 "rooms" tools (create_room,
- * place_device_in_room). Each entry is a plain JSON-Schema tool definition; the call
+ * connect_devices_batch), the Ship-4 "rooms" tools (create_room,
+ * place_device_in_room), and the Ship-5 "annotations" tool (add_note). Each entry is
+ * a plain JSON-Schema tool definition; the call
  * is relayed verbatim to the editor over the bridge, which validates and executes it
  * against the live store.
  *
@@ -232,6 +233,21 @@ export const TOOLS: ToolDef[] = [
         y: { type: "number", description: "Optional Y relative to the room's top-left corner (default 16)." },
       },
       required: ["deviceId", "roomId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "add_note",
+    description:
+      "Add a text note (a sticky-note card) to the canvas to annotate or explain the schematic. The text is shown literally (it is escaped, and line breaks are kept). Returns the new note's id. Notes can't yet be listed, edited, or deleted through the assistant — do that in the editor.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        text: { type: "string", description: "The note's text. Shown literally; newlines become line breaks." },
+        x: { type: "number", description: "Note top-left X position on the canvas." },
+        y: { type: "number", description: "Note top-left Y position on the canvas." },
+      },
+      required: ["text", "x", "y"],
       additionalProperties: false,
     },
   },

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -5,8 +5,9 @@
  * place_device_in_room), the Ship-5 "annotations" tool (add_note), the Ship-6
  * "slots / modular chassis" tools (list_slot_cards, install_card, remove_card), and the
  * Ship-7 "racks / rack elevation" tools (list_racks, create_rack, place_device_in_rack,
- * remove_device_from_rack), and the Ship-8 "notes" tools (update_note, delete_note;
- * get_schematic also reports rooms + notes). Each entry is a plain JSON-Schema tool
+ * remove_device_from_rack), the Ship-8 "notes" tools (update_note, delete_note;
+ * get_schematic also reports rooms + notes), and the Ship-9 "batch structural" tools
+ * (install_card_batch, place_device_in_rack_batch). Each entry is a plain JSON-Schema tool
  * definition; the call is relayed verbatim to the editor over the bridge, which validates
  * and executes it against the live store.
  *
@@ -377,6 +378,63 @@ export const TOOLS: ToolDef[] = [
         noteId: { type: "string", description: "The note id from get_schematic's notes." },
       },
       required: ["noteId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "install_card_batch",
+    description:
+      "Install several expansion cards into modular-chassis slots in one call — use this instead of repeated install_card calls. Best-effort: each install is attempted independently and the result lists per-item success or failure. Items are applied in array order, so an earlier install can affect a later one (two installs into the same slot leave only the first; a card that adds sub-slots can make a later install into one of them valid). Each card's slot family must match its slot, and a filled slot is never silently overwritten.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        installs: {
+          type: "array",
+          minItems: 1,
+          maxItems: 100,
+          description: "The cards to install.",
+          items: {
+            type: "object",
+            properties: {
+              deviceId: { type: "string", description: "The modular device (chassis) id." },
+              slotId: { type: "string", description: "The empty slot's id from get_device's slots." },
+              cardTemplateId: { type: "string", description: "A card templateId from list_slot_cards." },
+            },
+            required: ["deviceId", "slotId", "cardTemplateId"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["installs"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "place_device_in_rack_batch",
+    description:
+      "Mount several devices into racks in one call — use this instead of repeated place_device_in_rack calls. Best-effort: each placement is attempted independently and the result lists per-item success or failure. Placements are applied in array order, so an earlier one can affect a later one (it consumes the U span / half-rack side; a device already placed by an earlier item is rejected by a later one). Each item names its own rack; the same occupancy, 2-post-rear, already-placed and oversize/shelf-only rules as place_device_in_rack apply per item.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        placements: {
+          type: "array",
+          minItems: 1,
+          maxItems: 100,
+          description: "The rack placements to make.",
+          items: {
+            type: "object",
+            properties: {
+              deviceId: { type: "string", description: "The device id from get_schematic / list_devices." },
+              rackId: { type: "string", description: "The target rack id from list_racks." },
+              uPosition: { type: "number", description: "Bottom U position (1-based, from the bottom)." },
+              face: { type: "string", enum: ["front", "rear"], description: "Which face to mount on (default \"front\")." },
+            },
+            required: ["deviceId", "rackId", "uPosition"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["placements"],
       additionalProperties: false,
     },
   },

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -2,9 +2,10 @@
  * MCP tool catalog: the Ship-1 "working core" tools, the Ship-2 "editing & layout"
  * tools (move_device, delete_connection), the Ship-3 "batch" tools (add_devices,
  * connect_devices_batch), the Ship-4 "rooms" tools (create_room,
- * place_device_in_room), the Ship-5 "annotations" tool (add_note), and the Ship-6
- * "slots / modular chassis" tools (list_slot_cards, install_card, remove_card). Each
- * entry is a plain JSON-Schema tool definition; the call
+ * place_device_in_room), the Ship-5 "annotations" tool (add_note), the Ship-6
+ * "slots / modular chassis" tools (list_slot_cards, install_card, remove_card), and the
+ * Ship-7 "racks / rack elevation" tools (list_racks, create_rack, place_device_in_rack,
+ * remove_device_from_rack). Each entry is a plain JSON-Schema tool definition; the call
  * is relayed verbatim to the editor over the bridge, which validates and executes it
  * against the live store.
  *
@@ -292,6 +293,62 @@ export const TOOLS: ToolDef[] = [
         slotId: { type: "string", description: "The filled slot's id from get_device's slots." },
       },
       required: ["deviceId", "slotId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_racks",
+    description:
+      "List the rack elevations: every rack-elevation page, each rack on it (id, label, type, height in U, depth) and the devices currently placed in each rack (placementId, device, U position, face). Rack elevations are a separate view from the schematic canvas. Call this first to get the pageId/rackId/placementId values the other rack tools need.",
+    inputSchema: noArgs,
+  },
+  {
+    name: "create_rack",
+    description:
+      "Create an equipment rack. If pageId is omitted a new rack-elevation page is created to hold it; pass a pageId from list_racks to add the rack to an existing page. Returns the new pageId and rackId. Height (U) and depth (mm) are clamped to the editor's ranges (2–60U, 100–2000mm).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        label: { type: "string", description: "Rack name (default \"Rack\")." },
+        heightU: { type: "number", description: "Rack height in rack units (2–60, default 42)." },
+        rackType: {
+          type: "string",
+          enum: ["floor-19", "wall-mount", "desktop", "open-2post", "open-4post"],
+          description: "Rack enclosure type (default \"floor-19\").",
+        },
+        depthMm: { type: "number", description: "Rack depth in mm (100–2000, default 600)." },
+        pageId: { type: "string", description: "Existing rack-elevation page id from list_racks. Omit to create a new page." },
+        pageLabel: { type: "string", description: "Name for the new rack page (used only when pageId is omitted; default \"Rack Elevation\")." },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "place_device_in_rack",
+    description:
+      "Mount a device from the schematic into a rack at a U position. The device's height in U is inferred from its physical dimensions, and half-rack gear is placed on a free side automatically. Fails if the U span is occupied or out of the rack's bounds, if the device is already placed in a rack (remove it first), for a rear placement on a 2-post rack, or if the device is too small to rack-mount directly (it needs a shelf — add that in the editor) or too wide to fit. uPosition is 1-based from the bottom.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        deviceId: { type: "string", description: "The device id from get_schematic / list_devices." },
+        rackId: { type: "string", description: "The target rack id from list_racks." },
+        uPosition: { type: "number", description: "Bottom U position (1-based, from the bottom)." },
+        face: { type: "string", enum: ["front", "rear"], description: "Which face to mount on (default \"front\")." },
+      },
+      required: ["deviceId", "rackId", "uPosition"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "remove_device_from_rack",
+    description:
+      "Remove a device's rack placement (from list_racks) so its U position frees up. The device stays on the schematic; only its position in the rack is removed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        placementId: { type: "string", description: "The placement id from list_racks." },
+      },
+      required: ["placementId"],
       additionalProperties: false,
     },
   },

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -5,9 +5,10 @@
  * place_device_in_room), the Ship-5 "annotations" tool (add_note), the Ship-6
  * "slots / modular chassis" tools (list_slot_cards, install_card, remove_card), and the
  * Ship-7 "racks / rack elevation" tools (list_racks, create_rack, place_device_in_rack,
- * remove_device_from_rack). Each entry is a plain JSON-Schema tool definition; the call
- * is relayed verbatim to the editor over the bridge, which validates and executes it
- * against the live store.
+ * remove_device_from_rack), and the Ship-8 "notes" tools (update_note, delete_note;
+ * get_schematic also reports rooms + notes). Each entry is a plain JSON-Schema tool
+ * definition; the call is relayed verbatim to the editor over the bridge, which validates
+ * and executes it against the live store.
  *
  * In AV terms the user sees Device / Connection / Port; these tool names and the
  * docs use the same AV language.
@@ -24,7 +25,7 @@ export const TOOLS: ToolDef[] = [
   {
     name: "get_schematic",
     description:
-      "Get a summary of the current schematic: its name, every device (with ports) and every connection. Call this first to see what already exists.",
+      "Get a summary of the current schematic: its name, every device (with ports), every connection, every room (container) and every note (text annotation). Call this first to see what already exists. Note ids and room ids here feed update_note/delete_note and place_device_in_room.",
     inputSchema: noArgs,
   },
   {
@@ -349,6 +350,33 @@ export const TOOLS: ToolDef[] = [
         placementId: { type: "string", description: "The placement id from list_racks." },
       },
       required: ["placementId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "update_note",
+    description:
+      "Replace the text of an existing note (text annotation). Get note ids from get_schematic. The text is shown literally (HTML-escaped) and newlines become line breaks; this replaces the note's whole content, so a note with rich formatting from the editor becomes plain text.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        noteId: { type: "string", description: "The note id from get_schematic's notes." },
+        text: { type: "string", description: "The new note text." },
+      },
+      required: ["noteId", "text"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "delete_note",
+    description:
+      "Delete a note (text annotation) by id. Get note ids from get_schematic. Only the note is removed; devices, rooms and connections are untouched.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        noteId: { type: "string", description: "The note id from get_schematic's notes." },
+      },
+      required: ["noteId"],
       additionalProperties: false,
     },
   },

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,8 +1,9 @@
 /**
- * MCP tool catalog: the Ship-1 "working core" tools plus the Ship-2 "editing &
- * layout" tools (move_device, delete_connection). Each entry is a plain JSON-Schema
- * tool definition; the call is relayed verbatim to the editor over the bridge,
- * which validates and executes it against the live store.
+ * MCP tool catalog: the Ship-1 "working core" tools, the Ship-2 "editing & layout"
+ * tools (move_device, delete_connection), and the Ship-3 "batch" tools (add_devices,
+ * connect_devices_batch). Each entry is a plain JSON-Schema tool definition; the call
+ * is relayed verbatim to the editor over the bridge, which validates and executes it
+ * against the live store.
  *
  * In AV terms the user sees Device / Connection / Port; these tool names and the
  * docs use the same AV language.
@@ -137,6 +138,66 @@ export const TOOLS: ToolDef[] = [
         connectionId: { type: "string", description: "The connection (edge) id to remove." },
       },
       required: ["connectionId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "add_devices",
+    description:
+      "Add several devices to the canvas in one call — use this instead of repeated add_device calls when placing many devices. Best-effort: each device is added independently, and the result lists per-device success or failure (with the new device id) so you can retry only the ones that failed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        devices: {
+          type: "array",
+          minItems: 1,
+          maxItems: 100,
+          description: "The devices to add.",
+          items: {
+            type: "object",
+            properties: {
+              templateId: { type: "string", description: "Template id from search_templates." },
+              label: { type: "string", description: "Optional custom name; defaults to the template name." },
+              x: { type: "number", description: "Optional canvas X position." },
+              y: { type: "number", description: "Optional canvas Y position." },
+            },
+            required: ["templateId"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["devices"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "connect_devices_batch",
+    description:
+      "Make several connections in one call — use this instead of repeated connect_devices calls. Best-effort: each connection is attempted independently and the result lists per-connection success or failure. Connections are applied in array order, so an earlier one can affect a later one (for example, using up a single-link port). For two-sided ports give the face: bidirectional ports use 'in'/'out'; passthrough ports use 'rear'/'front'.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        connections: {
+          type: "array",
+          minItems: 1,
+          maxItems: 100,
+          description: "The connections to make.",
+          items: {
+            type: "object",
+            properties: {
+              sourceNodeId: { type: "string" },
+              sourcePortId: { type: "string" },
+              sourceFace: { type: "string", enum: ["in", "out", "rear", "front"], description: "Required only for two-sided source ports." },
+              targetNodeId: { type: "string" },
+              targetPortId: { type: "string" },
+              targetFace: { type: "string", enum: ["in", "out", "rear", "front"], description: "Required only for two-sided target ports." },
+            },
+            required: ["sourceNodeId", "sourcePortId", "targetNodeId", "targetPortId"],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ["connections"],
       additionalProperties: false,
     },
   },

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -2,8 +2,9 @@
  * MCP tool catalog: the Ship-1 "working core" tools, the Ship-2 "editing & layout"
  * tools (move_device, delete_connection), the Ship-3 "batch" tools (add_devices,
  * connect_devices_batch), the Ship-4 "rooms" tools (create_room,
- * place_device_in_room), and the Ship-5 "annotations" tool (add_note). Each entry is
- * a plain JSON-Schema tool definition; the call
+ * place_device_in_room), the Ship-5 "annotations" tool (add_note), and the Ship-6
+ * "slots / modular chassis" tools (list_slot_cards, install_card, remove_card). Each
+ * entry is a plain JSON-Schema tool definition; the call
  * is relayed verbatim to the editor over the bridge, which validates and executes it
  * against the live store.
  *
@@ -248,6 +249,49 @@ export const TOOLS: ToolDef[] = [
         y: { type: "number", description: "Note top-left Y position on the canvas." },
       },
       required: ["text", "x", "y"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "list_slot_cards",
+    description:
+      "List the expansion cards that fit a given slot on a modular device (chassis). A device's slots come from get_device. Returns the card templateId values to pass to install_card. If the full community library hasn't been loaded yet this session, call search_templates once first so live-library cards are included.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        deviceId: { type: "string", description: "The modular device (chassis) id." },
+        slotId: { type: "string", description: "The slot id from get_device's slots." },
+      },
+      required: ["deviceId", "slotId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "install_card",
+    description:
+      "Install an expansion card into an empty slot on a modular device. Use list_slot_cards to get a compatible card templateId. The card's slot family must match the slot's, or the call is refused. If the slot already holds a card, remove it first with remove_card (installing never silently replaces a card). Returns the installed card and the ids of the ports it added.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        deviceId: { type: "string", description: "The modular device (chassis) id." },
+        slotId: { type: "string", description: "The empty slot's id from get_device's slots." },
+        cardTemplateId: { type: "string", description: "A card templateId from list_slot_cards." },
+      },
+      required: ["deviceId", "slotId", "cardTemplateId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "remove_card",
+    description:
+      "Remove the card from a filled slot on a modular device, emptying the slot. This also removes the card's ports and any connections on them. Fails if the slot is already empty.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        deviceId: { type: "string", description: "The modular device (chassis) id." },
+        slotId: { type: "string", description: "The filled slot's id from get_device's slots." },
+      },
+      required: ["deviceId", "slotId"],
       additionalProperties: false,
     },
   },

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -328,7 +328,7 @@ export const TOOLS: ToolDef[] = [
   {
     name: "place_device_in_rack",
     description:
-      "Mount a device from the schematic into a rack at a U position. The device's height in U is inferred from its physical dimensions, and half-rack gear is placed on a free side automatically. Fails if the U span is occupied or out of the rack's bounds, if the device is already placed in a rack (remove it first), for a rear placement on a 2-post rack, or if the device is too small to rack-mount directly (it needs a shelf — add that in the editor) or too wide to fit. uPosition is 1-based from the bottom.",
+      "Mount a device from the schematic into a rack at a U position. The device's height in U is inferred from its physical dimensions, and half-rack gear is placed on a free side automatically. Gear too small to rack-mount directly is placed on an auto-created 1U shelf (the response includes that shelfId; remove_device_from_rack cleans the shelf up for you unless you've since edited it in the editor). Fails if the U span is occupied or out of the rack's bounds, if the device is already placed in a rack (remove it first), for a rear placement on a 2-post rack, or if the device is too wide to fit a 19\" rack. uPosition is 1-based from the bottom.",
     inputSchema: {
       type: "object",
       properties: {
@@ -344,7 +344,7 @@ export const TOOLS: ToolDef[] = [
   {
     name: "remove_device_from_rack",
     description:
-      "Remove a device's rack placement (from list_racks) so its U position frees up. The device stays on the schematic; only its position in the rack is removed.",
+      "Remove a device's rack placement (from list_racks) so its U position frees up. The device stays on the schematic; only its position in the rack is removed. If the device sat on a 1U shelf that this bridge auto-created for it (and you haven't adopted that shelf by editing it or adding another device), the empty shelf is removed too (its id is returned as removedShelfId).",
     inputSchema: {
       type: "object",
       properties: {
@@ -412,7 +412,7 @@ export const TOOLS: ToolDef[] = [
   {
     name: "place_device_in_rack_batch",
     description:
-      "Mount several devices into racks in one call — use this instead of repeated place_device_in_rack calls. Best-effort: each placement is attempted independently and the result lists per-item success or failure. Placements are applied in array order, so an earlier one can affect a later one (it consumes the U span / half-rack side; a device already placed by an earlier item is rejected by a later one). Each item names its own rack; the same occupancy, 2-post-rear, already-placed and oversize/shelf-only rules as place_device_in_rack apply per item.",
+      "Mount several devices into racks in one call — use this instead of repeated place_device_in_rack calls. Best-effort: each placement is attempted independently and the result lists per-item success or failure. Placements are applied in array order, so an earlier one can affect a later one (it consumes the U span / half-rack side; a device already placed by an earlier item is rejected by a later one). Each item names its own rack; the same occupancy, 2-post-rear, already-placed, oversize and shelf-only (auto-shelf) handling as place_device_in_rack applies per item.",
     inputSchema: {
       type: "object",
       properties: {

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,7 +1,8 @@
 /**
  * MCP tool catalog: the Ship-1 "working core" tools, the Ship-2 "editing & layout"
- * tools (move_device, delete_connection), and the Ship-3 "batch" tools (add_devices,
- * connect_devices_batch). Each entry is a plain JSON-Schema tool definition; the call
+ * tools (move_device, delete_connection), the Ship-3 "batch" tools (add_devices,
+ * connect_devices_batch), and the Ship-4 "rooms" tools (create_room,
+ * place_device_in_room). Each entry is a plain JSON-Schema tool definition; the call
  * is relayed verbatim to the editor over the bridge, which validates and executes it
  * against the live store.
  *
@@ -198,6 +199,39 @@ export const TOOLS: ToolDef[] = [
         },
       },
       required: ["connections"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "create_room",
+    description:
+      "Create a room — a labelled container on the canvas that devices can be placed inside (use place_device_in_room). Returns the new room's id. width/height are optional (default 400x300; minimums 200x150). Any existing devices already inside the new room's bounds are absorbed into it and listed in absorbedDeviceIds (their coordinates become relative to the room, so re-read them before reusing old positions).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        label: { type: "string", description: "The room's name, shown on the canvas." },
+        x: { type: "number", description: "Room top-left X position on the canvas." },
+        y: { type: "number", description: "Room top-left Y position on the canvas." },
+        width: { type: "number", description: "Optional room width (minimum 200; default 400)." },
+        height: { type: "number", description: "Optional room height (minimum 150; default 300)." },
+      },
+      required: ["label", "x", "y"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "place_device_in_room",
+    description:
+      "Place a device inside a room. x and y are the device's position relative to the room's top-left corner (default 16,16). The device's center must land inside the room or the call fails without changing anything, so a device is never reported as placed when it isn't. To reposition a device that is already in a room, use move_device instead.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        deviceId: { type: "string", description: "The device id." },
+        roomId: { type: "string", description: "The room id (from get_schematic or create_room)." },
+        x: { type: "number", description: "Optional X relative to the room's top-left corner (default 16)." },
+        y: { type: "number", description: "Optional Y relative to the room's top-left corner (default 16)." },
+      },
+      required: ["deviceId", "roomId"],
       additionalProperties: false,
     },
   },

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -1,5 +1,6 @@
 /**
- * MCP tool catalog for Ship 1 ("working core"). Each entry is a plain JSON-Schema
+ * MCP tool catalog: the Ship-1 "working core" tools plus the Ship-2 "editing &
+ * layout" tools (move_device, delete_connection). Each entry is a plain JSON-Schema
  * tool definition; the call is relayed verbatim to the editor over the bridge,
  * which validates and executes it against the live store.
  *
@@ -108,6 +109,34 @@ export const TOOLS: ToolDef[] = [
       type: "object",
       properties: { nodeId: { type: "string", description: "The device id." } },
       required: ["nodeId"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "move_device",
+    description:
+      "Reposition a device on the canvas. x and y are in the same coordinate space get_device/get_schematic report for that device — canvas coordinates for a top-level device, or coordinates relative to its room/rack when the device has a parentId. This moves the device within its current container; it does not move a device into or out of a room or rack.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        nodeId: { type: "string", description: "The device id." },
+        x: { type: "number", description: "New X position." },
+        y: { type: "number", description: "New Y position." },
+      },
+      required: ["nodeId", "x", "y"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "delete_connection",
+    description:
+      "Remove a single connection from the canvas by its id (the connection ids are returned by get_schematic and connect_devices). Stubbed connections cannot be removed this way yet.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        connectionId: { type: "string", description: "The connection (edge) id to remove." },
+      },
+      required: ["connectionId"],
       additionalProperties: false,
     },
   },

--- a/mcp-server/src/tools.ts
+++ b/mcp-server/src/tools.ts
@@ -36,7 +36,8 @@ export const TOOLS: ToolDef[] = [
   },
   {
     name: "get_device",
-    description: "Get one device's details, including its ports (id, label, direction, signal type).",
+    description:
+      "Get one device's details, including its ports (id, label, direction, signal type) and, for a modular chassis, its slots (id and slot family) — the slotId values that list_slot_cards and install_card need.",
     inputSchema: {
       type: "object",
       properties: { nodeId: { type: "string", description: "The device id." } },

--- a/src/__tests__/mcpEditing.test.ts
+++ b/src/__tests__/mcpEditing.test.ts
@@ -13,7 +13,15 @@
  * mcpValidation.test.ts.
  */
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
-import type { ConnectionEdge, DeviceData, NoteData, SchematicNode, StubLabelData } from "../types";
+import type {
+  ConnectionEdge,
+  DeviceData,
+  DeviceTemplate,
+  InstalledSlot,
+  NoteData,
+  SchematicNode,
+  StubLabelData,
+} from "../types";
 
 class MemStorage {
   private m = new Map<string, string>();
@@ -277,6 +285,222 @@ describe("add_note handler (add_note tool)", () => {
     expect(() => handlers.add_note({ text: "ok", x: NaN, y: 0 })).toThrow();
     expect(() => handlers.add_note({ text: "ok", x: 0 } as Record<string, unknown>)).toThrow();
     expect(useSchematicStore.getState().nodes.some((n) => n.type === "note")).toBe(false);
+  });
+});
+
+describe("slot tools (list_slot_cards / install_card / remove_card)", () => {
+  // A chassis device carrying one empty slot of family "fam-a".
+  function chassis(id: string, slots: InstalledSlot[]): SchematicNode {
+    return {
+      id,
+      type: "device",
+      position: { x: 0, y: 0 },
+      data: { label: id, deviceType: "chassis", ports: [], slots } as DeviceData,
+    } as SchematicNode;
+  }
+  function emptySlot(slotId: string, slotFamily: string): InstalledSlot {
+    return { slotId, label: slotId, slotFamily, portIds: [] };
+  }
+  // A card template (in customTemplates so getTemplateById resolves it without network).
+  function cardTpl(id: string, slotFamily: string, opts: { ports?: number; slots?: DeviceTemplate["slots"] } = {}): DeviceTemplate {
+    return {
+      id,
+      label: id,
+      deviceType: id,
+      slotFamily,
+      ports: Array.from({ length: opts.ports ?? 1 }, (_, i) => ({
+        id: `p${i}`,
+        label: `P${i}`,
+        direction: "input",
+        signalType: "hdmi",
+      })),
+      ...(opts.slots ? { slots: opts.slots } : {}),
+    } as DeviceTemplate;
+  }
+
+  function slotsOf(deviceId: string) {
+    return ((useSchematicStore.getState().nodes.find((n) => n.id === deviceId)!.data as DeviceData).slots ?? []);
+  }
+
+  it("get_device exposes slots and get_schematic exposes slotCount", () => {
+    useSchematicStore.setState({
+      nodes: [chassis("chassis-1", [emptySlot("slot-1", "fam-a")])],
+      edges: [],
+      customTemplates: [],
+    });
+    const dev = handlers.get_device({ nodeId: "chassis-1" }) as { slots: { slotId: string; filled: boolean; slotFamily?: string }[] };
+    expect(dev.slots).toHaveLength(1);
+    expect(dev.slots[0]).toMatchObject({ slotId: "slot-1", filled: false, slotFamily: "fam-a" });
+    const schem = handlers.get_schematic({}) as { devices: { nodeId: string; slotCount: number }[] };
+    expect(schem.devices.find((d) => d.nodeId === "chassis-1")!.slotCount).toBe(1);
+  });
+
+  it("list_slot_cards returns only id-backed cards whose family fits the slot", () => {
+    useSchematicStore.setState({
+      nodes: [chassis("chassis-1", [emptySlot("slot-1", "fam-a")])],
+      edges: [],
+      customTemplates: [cardTpl("card-a", "fam-a"), cardTpl("card-b", "fam-b"), { ...cardTpl("noid", "fam-a"), id: undefined } as DeviceTemplate],
+    });
+    const res = handlers.list_slot_cards({ deviceId: "chassis-1", slotId: "slot-1" }) as {
+      slotFamily?: string;
+      cards: { templateId: string }[];
+    };
+    expect(res.slotFamily).toBe("fam-a");
+    expect(res.cards.map((c) => c.templateId)).toEqual(["card-a"]); // card-b wrong family, noid filtered out
+  });
+
+  it("install_card fills the slot, adds the card's ports, and is a single undo step", () => {
+    useSchematicStore.setState({
+      nodes: [chassis("chassis-1", [emptySlot("slot-1", "fam-a")])],
+      edges: [],
+      customTemplates: [cardTpl("card-a", "fam-a", { ports: 2 })],
+    });
+    const undoBefore = useSchematicStore.getState().undoSize;
+    const res = handlers.install_card({ deviceId: "chassis-1", slotId: "slot-1", cardTemplateId: "card-a" }) as {
+      cardTemplateId: string;
+      portIds: string[];
+    };
+    expect(res.cardTemplateId).toBe("card-a");
+    expect(res.portIds).toHaveLength(2);
+    const slot = slotsOf("chassis-1").find((s) => s.slotId === "slot-1")!;
+    expect(slot.cardTemplateId).toBe("card-a");
+    // the card's ports are now on the device
+    expect((useSchematicStore.getState().nodes[0].data as DeviceData).ports).toHaveLength(2);
+    expect(useSchematicStore.getState().undoSize).toBe(undoBefore + 1);
+
+    useSchematicStore.getState().undo();
+    expect(slotsOf("chassis-1").find((s) => s.slotId === "slot-1")!.cardTemplateId).toBeUndefined();
+  });
+
+  it("install_card rejects a card whose family does not fit (no change, no spurious undo)", () => {
+    useSchematicStore.setState({
+      nodes: [chassis("chassis-1", [emptySlot("slot-1", "fam-a")])],
+      edges: [],
+      customTemplates: [cardTpl("card-b", "fam-b")],
+    });
+    const undoBefore = useSchematicStore.getState().undoSize;
+    expect(() => handlers.install_card({ deviceId: "chassis-1", slotId: "slot-1", cardTemplateId: "card-b" })).toThrow(/does not fit/);
+    expect(slotsOf("chassis-1")[0].cardTemplateId).toBeUndefined();
+    expect(useSchematicStore.getState().undoSize).toBe(undoBefore);
+  });
+
+  it("install_card refuses to overwrite a filled slot", () => {
+    useSchematicStore.setState({
+      nodes: [chassis("chassis-1", [emptySlot("slot-1", "fam-a")])],
+      edges: [],
+      customTemplates: [cardTpl("card-a", "fam-a"), cardTpl("card-a2", "fam-a")],
+    });
+    handlers.install_card({ deviceId: "chassis-1", slotId: "slot-1", cardTemplateId: "card-a" });
+    expect(() => handlers.install_card({ deviceId: "chassis-1", slotId: "slot-1", cardTemplateId: "card-a2" })).toThrow(/already holds a card/);
+  });
+
+  it("install_card rejects a missing slot or unknown card without a spurious undo", () => {
+    useSchematicStore.setState({
+      nodes: [chassis("chassis-1", [emptySlot("slot-1", "fam-a")])],
+      edges: [],
+      customTemplates: [cardTpl("card-a", "fam-a")],
+    });
+    const undoBefore = useSchematicStore.getState().undoSize;
+    expect(() => handlers.install_card({ deviceId: "chassis-1", slotId: "nope", cardTemplateId: "card-a" })).toThrow(/No slot found/);
+    expect(() => handlers.install_card({ deviceId: "chassis-1", slotId: "slot-1", cardTemplateId: "ghost" })).toThrow(/No card template/);
+    expect(useSchematicStore.getState().undoSize).toBe(undoBefore);
+  });
+
+  it("remove_card empties a filled slot and rejects an already-empty one (no spurious undo)", () => {
+    useSchematicStore.setState({
+      nodes: [chassis("chassis-1", [emptySlot("slot-1", "fam-a")])],
+      edges: [],
+      customTemplates: [cardTpl("card-a", "fam-a")],
+    });
+    handlers.install_card({ deviceId: "chassis-1", slotId: "slot-1", cardTemplateId: "card-a" });
+    const res = handlers.remove_card({ deviceId: "chassis-1", slotId: "slot-1" }) as { emptied: boolean };
+    expect(res.emptied).toBe(true);
+    expect(slotsOf("chassis-1").find((s) => s.slotId === "slot-1")!.cardTemplateId).toBeUndefined();
+
+    const undoBefore = useSchematicStore.getState().undoSize;
+    expect(() => handlers.remove_card({ deviceId: "chassis-1", slotId: "slot-1" })).toThrow(/already empty/);
+    expect(useSchematicStore.getState().undoSize).toBe(undoBefore);
+  });
+
+  it("supports installing a card into a nested sub-slot (slotFamily denormalized)", () => {
+    useSchematicStore.setState({
+      nodes: [chassis("chassis-1", [emptySlot("slot-1", "fam-a")])],
+      edges: [],
+      // card-parent fits slot-1 and itself defines a sub-slot of family fam-b.
+      customTemplates: [
+        cardTpl("card-parent", "fam-a", { slots: [{ id: "sub", label: "Sub", slotFamily: "fam-b" }] }),
+        cardTpl("card-sub", "fam-b"),
+      ],
+    });
+    handlers.install_card({ deviceId: "chassis-1", slotId: "slot-1", cardTemplateId: "card-parent" });
+    // installing the parent created a nested empty slot "slot-1/sub"
+    const nested = slotsOf("chassis-1").find((s) => s.parentSlotId === "slot-1");
+    expect(nested).toBeTruthy();
+    expect(nested!.slotFamily).toBe("fam-b");
+    // and a card can be installed into it
+    const res = handlers.install_card({ deviceId: "chassis-1", slotId: nested!.slotId, cardTemplateId: "card-sub" }) as { cardTemplateId: string };
+    expect(res.cardTemplateId).toBe("card-sub");
+    expect(slotsOf("chassis-1").find((s) => s.slotId === nested!.slotId)!.cardTemplateId).toBe("card-sub");
+  });
+
+  it("installing into a slot does not disturb a sibling whose id shares its prefix (segment-safe)", () => {
+    // "p1" and "p10" are distinct top-level slots; p10 holds a card with a nested
+    // sub-slot "p10/sub". A raw startsWith("p1") would wrongly treat p10/sub as a
+    // descendant of p1 and drop its card/ports when p1 is operated on.
+    useSchematicStore.setState({
+      nodes: [
+        {
+          id: "chassis-1",
+          type: "device",
+          position: { x: 0, y: 0 },
+          data: {
+            label: "chassis-1",
+            deviceType: "chassis",
+            ports: [{ id: "port-y", label: "Y", direction: "input", signalType: "hdmi" }],
+            slots: [
+              { slotId: "p1", label: "P1", slotFamily: "fam-a", portIds: [] },
+              { slotId: "p10", label: "P10", slotFamily: "fam-a", cardTemplateId: "card-x", cardLabel: "X", portIds: [] },
+              { slotId: "p10/sub", label: "Sub", slotFamily: "fam-b", parentSlotId: "p10", cardTemplateId: "card-y", cardLabel: "Y", portIds: ["port-y"] },
+            ] as InstalledSlot[],
+          } as DeviceData,
+        } as SchematicNode,
+      ],
+      edges: [],
+      customTemplates: [cardTpl("card-a", "fam-a")],
+    });
+    handlers.install_card({ deviceId: "chassis-1", slotId: "p1", cardTemplateId: "card-a" });
+    // p10's nested card and its port must be untouched.
+    const sub = slotsOf("chassis-1").find((s) => s.slotId === "p10/sub")!;
+    expect(sub.cardTemplateId).toBe("card-y");
+    expect((useSchematicStore.getState().nodes[0].data as DeviceData).ports.some((p) => p.id === "port-y")).toBe(true);
+  });
+
+  it("removeSlot is segment-safe too: removing p1 leaves sibling p10's nested slot intact", () => {
+    useSchematicStore.setState({
+      nodes: [
+        {
+          id: "chassis-1",
+          type: "device",
+          position: { x: 0, y: 0 },
+          data: {
+            label: "chassis-1",
+            deviceType: "chassis",
+            ports: [{ id: "port-y", label: "Y", direction: "input", signalType: "hdmi" }],
+            slots: [
+              { slotId: "p1", label: "P1", slotFamily: "fam-a", portIds: [] },
+              { slotId: "p10", label: "P10", slotFamily: "fam-a", cardTemplateId: "card-x", cardLabel: "X", portIds: [] },
+              { slotId: "p10/sub", label: "Sub", slotFamily: "fam-b", parentSlotId: "p10", cardTemplateId: "card-y", cardLabel: "Y", portIds: ["port-y"] },
+            ] as InstalledSlot[],
+          } as DeviceData,
+        } as SchematicNode,
+      ],
+      edges: [],
+    });
+    useSchematicStore.getState().removeSlot("chassis-1", "p1");
+    const slots = slotsOf("chassis-1");
+    expect(slots.some((s) => s.slotId === "p1")).toBe(false); // p1 gone
+    expect(slots.find((s) => s.slotId === "p10/sub")!.cardTemplateId).toBe("card-y"); // sibling's nested card intact
+    expect((useSchematicStore.getState().nodes[0].data as DeviceData).ports.some((p) => p.id === "port-y")).toBe(true);
   });
 });
 

--- a/src/__tests__/mcpEditing.test.ts
+++ b/src/__tests__/mcpEditing.test.ts
@@ -19,6 +19,10 @@ import type {
   DeviceTemplate,
   InstalledSlot,
   NoteData,
+  RackAccessory,
+  RackData,
+  RackDevicePlacement,
+  RackElevationPage,
   SchematicNode,
   StubLabelData,
 } from "../types";
@@ -520,5 +524,234 @@ describe("connection removal (delete_connection path)", () => {
     expect(useSchematicStore.getState().edges).toEqual([]);
     useSchematicStore.getState().undo();
     expect(useSchematicStore.getState().edges.map((e) => e.id)).toEqual(["edge-1"]);
+  });
+});
+
+describe("rack tools (list_racks / create_rack / place_device_in_rack / remove_device_from_rack)", () => {
+  // A rack-mountable device. Width/height drive inferRackForm: ~480mm wide + whole-U
+  // height -> "full"; ~220mm -> "half"; <200mm -> "shelf-only"; >~452mm -> "oversize".
+  function rackDevice(id: string, widthMm: number, heightMm: number): SchematicNode {
+    return {
+      id,
+      type: "device",
+      position: { x: 0, y: 0 },
+      data: { label: id, deviceType: "test", ports: [], widthMm, heightMm } as DeviceData,
+    } as SchematicNode;
+  }
+  function rack(id: string, opts: Partial<RackData> = {}): RackData {
+    return { id, label: id, rackType: "floor-19", heightU: 42, depthMm: 600, widthClass: "19in", position: { x: 0, y: 0 }, ...opts };
+  }
+  function rackPage(id: string, racks: RackData[] = [], placements: RackDevicePlacement[] = [], accessories: RackAccessory[] = []): RackElevationPage {
+    return { id, label: id, type: "rack-elevation", racks, placements, accessories };
+  }
+  function pages(): RackElevationPage[] {
+    return useSchematicStore.getState().pages.filter((p): p is RackElevationPage => p.type === "rack-elevation");
+  }
+  const FULL_1U = { widthMm: 480, heightMm: 44.45 };
+  const HALF_1U = { widthMm: 220, heightMm: 44.45 };
+
+  it("list_racks reports pages, racks and placements with resolved device labels", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")], [
+        { id: "pl-1", rackId: "rack-1", deviceNodeId: "device-1", uPosition: 3, face: "front" },
+      ])],
+    });
+    const res = handlers.list_racks({}) as {
+      pageCount: number;
+      pages: { pageId: string; racks: { rackId: string; heightU: number; placements: { placementId: string; deviceLabel: string | null; uPosition: number; heightU: number | null }[] }[] }[];
+    };
+    expect(res.pageCount).toBe(1);
+    expect(res.pages[0].pageId).toBe("rk-1");
+    expect(res.pages[0].racks[0].rackId).toBe("rack-1");
+    const pl = res.pages[0].racks[0].placements[0];
+    expect(pl).toMatchObject({ placementId: "pl-1", deviceLabel: "device-1", uPosition: 3, heightU: 1 });
+  });
+
+  it("create_rack with no pageId creates a rack page and a rack with defaults", () => {
+    useSchematicStore.setState({ nodes: [], edges: [], pages: [] });
+    const res = handlers.create_rack({ label: "Head End" }) as { pageId: string; rackId: string; rackType: string; heightU: number; depthMm: number; createdPage: boolean };
+    expect(res.createdPage).toBe(true);
+    expect(res).toMatchObject({ rackType: "floor-19", heightU: 42, depthMm: 600 });
+    const ps = pages();
+    expect(ps).toHaveLength(1);
+    expect(ps[0].id).toBe(res.pageId);
+    expect(ps[0].racks[0].id).toBe(res.rackId);
+    expect(ps[0].racks[0].label).toBe("Head End");
+  });
+
+  it("create_rack with an existing pageId adds the rack at a page-local x offset", () => {
+    useSchematicStore.setState({ nodes: [], edges: [], pages: [rackPage("rk-1", [rack("rack-1", { position: { x: 0, y: 0 } })])] });
+    const res = handlers.create_rack({ pageId: "rk-1", label: "Second" }) as { pageId: string; rackId: string; createdPage: boolean };
+    expect(res.createdPage).toBe(false);
+    expect(res.pageId).toBe("rk-1");
+    const page = pages()[0];
+    expect(page.racks).toHaveLength(2);
+    expect(page.racks[1].position.x).toBe(400); // second rack on the page
+  });
+
+  it("create_rack rejects an unknown pageId and an invalid rackType", () => {
+    useSchematicStore.setState({ nodes: [], edges: [], pages: [] });
+    expect(() => handlers.create_rack({ pageId: "nope" })).toThrow(/No rack-elevation page/);
+    expect(() => handlers.create_rack({ rackType: "server-rack" })).toThrow(/rackType must be one of/);
+  });
+
+  it("place_device_in_rack mounts a full-width device and records the placement", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const res = handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 5 }) as { placementId: string; form: string; heightU: number; face: string };
+    expect(res).toMatchObject({ form: "full", heightU: 1, face: "front" });
+    const page = pages()[0];
+    expect(page.placements).toHaveLength(1);
+    expect(page.placements[0]).toMatchObject({ deviceNodeId: "device-1", uPosition: 5, face: "front" });
+  });
+
+  it("place_device_in_rack rejects an occupied U range (addPlacementSmart does not check)", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", FULL_1U.widthMm, FULL_1U.heightMm), rackDevice("device-2", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 1 });
+    expect(() => handlers.place_device_in_rack({ deviceId: "device-2", rackId: "rack-1", uPosition: 1 })).toThrow(/occupied|out of bounds/);
+    expect(pages()[0].placements).toHaveLength(1); // the overlapping placement was not created
+  });
+
+  it("place_device_in_rack rejects a U position past the rack's height", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1", { heightU: 4 })])],
+    });
+    expect(() => handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 5 })).toThrow(/occupied|out of bounds/);
+  });
+
+  it("place_device_in_rack refuses to place a device that is already in a rack", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 1 });
+    expect(() => handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 10 })).toThrow(/already placed/);
+  });
+
+  it("place_device_in_rack rejects an oversize device", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", 800, 44.45)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    expect(() => handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 1 })).toThrow(/oversize/);
+  });
+
+  it("place_device_in_rack rejects a rear placement on a 2-post rack", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1", { rackType: "open-2post" })])],
+    });
+    expect(() => handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 1, face: "rear" })).toThrow(/2-post|rear/);
+  });
+
+  it("place_device_in_rack fits two half-rack devices side by side at the same U", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", HALF_1U.widthMm, HALF_1U.heightMm), rackDevice("device-2", HALF_1U.widthMm, HALF_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const a = handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 1 }) as { form: string; halfRackSide?: string };
+    const b = handlers.place_device_in_rack({ deviceId: "device-2", rackId: "rack-1", uPosition: 1 }) as { form: string; halfRackSide?: string };
+    expect(a.form).toBe("half");
+    expect(b.form).toBe("half");
+    // The two land on opposite sides (the exact validated side is passed to the store).
+    expect(a.halfRackSide).not.toBe(b.halfRackSide);
+    expect(pages()[0].placements).toHaveLength(2);
+  });
+
+  it("place_device_in_rack is undoable", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 1 });
+    expect(pages()[0].placements).toHaveLength(1);
+    useSchematicStore.getState().undo();
+    expect(pages()[0].placements).toHaveLength(0);
+  });
+
+  it("remove_device_from_rack removes a placement and rejects an unknown id", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")], [
+        { id: "pl-1", rackId: "rack-1", deviceNodeId: "device-1", uPosition: 1, face: "front" },
+      ])],
+    });
+    const res = handlers.remove_device_from_rack({ placementId: "pl-1" }) as { removed: boolean };
+    expect(res.removed).toBe(true);
+    expect(pages()[0].placements).toHaveLength(0);
+    expect(() => handlers.remove_device_from_rack({ placementId: "pl-404" })).toThrow(/No rack placement/);
+  });
+
+  it("place_device_in_rack rejects shelf-only gear (shelf placement is an editor task) and creates nothing", () => {
+    // ~150mm wide -> shelf-only (too small for a direct rack-mount panel).
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", 150, 50)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    expect(() => handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 })).toThrow(/needs a shelf|too small/);
+    // The bridge never auto-creates a shelf, so nothing is left behind.
+    expect(pages()[0].placements).toHaveLength(0);
+    expect(pages()[0].accessories).toHaveLength(0);
+  });
+
+  it("list_racks reports rack accessories so a U blocked by a shelf or panel is visible", () => {
+    useSchematicStore.setState({
+      nodes: [],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")], [], [
+        { id: "acc-1", rackId: "rack-1", type: "shelf", uPosition: 4, heightU: 1, face: "front" },
+      ])],
+    });
+    const listed = handlers.list_racks({}) as { pages: { racks: { accessories: { accessoryId: string; type: string; uPosition: number; heightU: number }[] }[] }[] };
+    expect(listed.pages[0].racks[0].accessories).toHaveLength(1);
+    expect(listed.pages[0].racks[0].accessories[0]).toMatchObject({ accessoryId: "acc-1", type: "shelf", uPosition: 4, heightU: 1 });
+  });
+
+  it("create_rack fails on an ambiguous pageId (duplicate page ids) rather than writing to both", () => {
+    useSchematicStore.setState({
+      nodes: [],
+      edges: [],
+      pages: [rackPage("dup", [rack("rack-1")]), rackPage("dup", [rack("rack-2")])],
+    });
+    expect(() => handlers.create_rack({ pageId: "dup", label: "X" })).toThrow(/ambiguous/);
+  });
+
+  it("place_device_in_rack rejects a U blocked by an accessory (not just by another device)", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")], [], [
+        { id: "acc-1", rackId: "rack-1", type: "shelf", uPosition: 1, heightU: 1, face: "front" },
+      ])],
+    });
+    expect(() => handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 1 })).toThrow(/occupied|out of bounds/);
+    expect(pages()[0].placements).toHaveLength(0);
+  });
+
+  it("place_device_in_rack rejects an ambiguous rackId (duplicate rack ids across pages)", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-dup")]), rackPage("rk-2", [rack("rack-dup")])],
+    });
+    expect(() => handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-dup", uPosition: 1 })).toThrow(/ambiguous/);
   });
 });

--- a/src/__tests__/mcpEditing.test.ts
+++ b/src/__tests__/mcpEditing.test.ts
@@ -1,15 +1,19 @@
 /**
- * Store-level tests for the Ship-2 "editing & layout" MCP tools' mutation paths:
- *   - moveDevice (the move_device tool) — repositions a node in one undo step.
- *   - onEdgesChange remove (the delete_connection tool) — removes a single edge.
+ * Store-level tests for the Ship-2/3/4 "editing & layout / rooms" MCP tools' mutation
+ * paths (moveDevice, addRoom, placeDeviceInRoom, connection removal) plus a
+ * handler-level test for the Ship-5 add_note tool — which has NO new store action, so
+ * its logic (trim validation, position validation, the id-snapshot, and the two-step
+ * addNote + updateNoteHtml flow) lives entirely in the bridge handler and is exercised
+ * here directly via the exported `handlers` map.
  *
  * The store reads editor preferences from localStorage at import time, so we install
- * a minimal in-memory localStorage and import the store dynamically afterwards. Pure
- * decision logic (validatePosition / planConnectionRemoval) is covered separately in
+ * a minimal in-memory localStorage and import the store (and the bridge handlers,
+ * which read the same store singleton) dynamically afterwards. Pure decision logic
+ * (validatePosition / planConnectionRemoval / noteTextToHtml) is covered separately in
  * mcpValidation.test.ts.
  */
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
-import type { ConnectionEdge, DeviceData, SchematicNode, StubLabelData } from "../types";
+import type { ConnectionEdge, DeviceData, NoteData, SchematicNode, StubLabelData } from "../types";
 
 class MemStorage {
   private m = new Map<string, string>();
@@ -22,10 +26,12 @@ class MemStorage {
 }
 
 let useSchematicStore: typeof import("../store")["useSchematicStore"];
+let handlers: typeof import("../mcpBridge")["handlers"];
 
 beforeAll(async () => {
   (globalThis as { localStorage?: unknown }).localStorage = new MemStorage();
   ({ useSchematicStore } = await import("../store"));
+  ({ handlers } = await import("../mcpBridge"));
 });
 
 function device(id: string, x: number, y: number): SchematicNode {
@@ -217,6 +223,60 @@ describe("placeDeviceInRoom (place_device_in_room path)", () => {
     useSchematicStore.getState().placeDeviceInRoom("device-1", "room-1", { x: 20, y: 30 });
     const follow = useSchematicStore.getState().nodes.find((n) => n.id === "stub-follow")!.data as StubLabelData;
     expect(follow.placed).toBe(false);
+  });
+});
+
+describe("add_note handler (add_note tool)", () => {
+  function noteHtml(noteId: string) {
+    const n = useSchematicStore.getState().nodes.find((x) => x.id === noteId)!;
+    return (n.data as NoteData).html;
+  }
+
+  it("creates a note with escaped HTML at the given position and returns its id", () => {
+    useSchematicStore.setState({ nodes: [], edges: [] });
+    const res = handlers.add_note({ text: "Head end\n<rack>", x: 40, y: 60 }) as {
+      noteId: string;
+      text: string;
+      position: { x: number; y: number };
+    };
+    expect(res.position).toEqual({ x: 40, y: 60 });
+    const note = useSchematicStore.getState().nodes.find((n) => n.type === "note")!;
+    expect(note.id).toBe(res.noteId);
+    expect(note.position).toEqual({ x: 40, y: 60 });
+    // Text is escaped (never raw markup) and newlines become <br>.
+    expect(noteHtml(res.noteId)).toBe("Head end<br>&lt;rack&gt;");
+  });
+
+  it("captures the new note's id even when notes already exist (snapshot is correct)", () => {
+    useSchematicStore.setState({ nodes: [], edges: [] });
+    const first = handlers.add_note({ text: "first", x: 0, y: 0 }) as { noteId: string };
+    const second = handlers.add_note({ text: "second", x: 10, y: 10 }) as { noteId: string };
+    expect(second.noteId).not.toBe(first.noteId);
+    expect(noteHtml(second.noteId)).toBe("second");
+    expect(noteHtml(first.noteId)).toBe("first");
+  });
+
+  it("is a single undo step (addNote pushes undo; updateNoteHtml does not)", () => {
+    useSchematicStore.setState({ nodes: [], edges: [] });
+    handlers.add_note({ text: "annotation", x: 5, y: 5 });
+    expect(useSchematicStore.getState().nodes.some((n) => n.type === "note")).toBe(true);
+    useSchematicStore.getState().undo();
+    expect(useSchematicStore.getState().nodes.some((n) => n.type === "note")).toBe(false);
+  });
+
+  it("rejects empty or whitespace-only text without creating a note", () => {
+    useSchematicStore.setState({ nodes: [], edges: [] });
+    expect(() => handlers.add_note({ text: "   ", x: 0, y: 0 })).toThrow(/text is required/);
+    expect(() => handlers.add_note({ text: "", x: 0, y: 0 })).toThrow(/text is required/);
+    expect(() => handlers.add_note({ x: 0, y: 0 } as Record<string, unknown>)).toThrow(/text is required/);
+    expect(useSchematicStore.getState().nodes.some((n) => n.type === "note")).toBe(false);
+  });
+
+  it("rejects a non-finite position without creating a note", () => {
+    useSchematicStore.setState({ nodes: [], edges: [] });
+    expect(() => handlers.add_note({ text: "ok", x: NaN, y: 0 })).toThrow();
+    expect(() => handlers.add_note({ text: "ok", x: 0 } as Record<string, unknown>)).toThrow();
+    expect(useSchematicStore.getState().nodes.some((n) => n.type === "note")).toBe(false);
   });
 });
 

--- a/src/__tests__/mcpEditing.test.ts
+++ b/src/__tests__/mcpEditing.test.ts
@@ -823,3 +823,99 @@ describe("notes & rooms read + notes CRUD (update_note / delete_note)", () => {
     expect(() => handlers.delete_note({ noteId: "device-1" })).toThrow(/not a note/);
   });
 });
+
+describe("batch structural ops (install_card_batch / place_device_in_rack_batch)", () => {
+  function chassis(id: string, slots: InstalledSlot[]): SchematicNode {
+    return { id, type: "device", position: { x: 0, y: 0 }, data: { label: id, deviceType: "chassis", ports: [], slots } as DeviceData } as SchematicNode;
+  }
+  function emptySlot(slotId: string, slotFamily: string): InstalledSlot {
+    return { slotId, label: slotId, slotFamily, portIds: [] };
+  }
+  function cardTpl(id: string, slotFamily: string): DeviceTemplate {
+    return { id, label: id, deviceType: id, slotFamily, ports: [{ id: "p0", label: "P0", direction: "input", signalType: "hdmi" }] } as DeviceTemplate;
+  }
+  function rackDevice(id: string, widthMm: number, heightMm: number): SchematicNode {
+    return { id, type: "device", position: { x: 0, y: 0 }, data: { label: id, deviceType: "test", ports: [], widthMm, heightMm } as DeviceData } as SchematicNode;
+  }
+  function rack(id: string): RackData {
+    return { id, label: id, rackType: "floor-19", heightU: 42, depthMm: 600, widthClass: "19in", position: { x: 0, y: 0 } };
+  }
+  function rackPage(id: string, racks: RackData[]): RackElevationPage {
+    return { id, label: id, type: "rack-elevation", racks, placements: [], accessories: [] };
+  }
+  function filledSlotIds() {
+    const slots = ((useSchematicStore.getState().nodes.find((n) => n.id === "chassis-1")!.data as DeviceData).slots ?? []);
+    return slots.filter((s) => s.cardTemplateId).map((s) => s.slotId);
+  }
+
+  it("install_card_batch installs every card and reports per-item success", () => {
+    useSchematicStore.setState({
+      nodes: [chassis("chassis-1", [emptySlot("slot-1", "fam-a"), emptySlot("slot-2", "fam-a")])],
+      edges: [],
+      customTemplates: [cardTpl("card-a", "fam-a")],
+    });
+    const res = handlers.install_card_batch({ installs: [
+      { deviceId: "chassis-1", slotId: "slot-1", cardTemplateId: "card-a" },
+      { deviceId: "chassis-1", slotId: "slot-2", cardTemplateId: "card-a" },
+    ] }) as { succeeded: number; failed: number };
+    expect(res).toMatchObject({ succeeded: 2, failed: 0 });
+    expect(filledSlotIds().sort()).toEqual(["slot-1", "slot-2"]);
+  });
+
+  it("install_card_batch is best-effort and a failed item pushes no undo step", () => {
+    useSchematicStore.setState({
+      nodes: [chassis("chassis-1", [emptySlot("slot-1", "fam-a")])],
+      edges: [],
+      customTemplates: [cardTpl("card-a", "fam-a")],
+    });
+    const undoBefore = useSchematicStore.getState().undoSize;
+    const res = handlers.install_card_batch({ installs: [
+      { deviceId: "chassis-1", slotId: "slot-1", cardTemplateId: "card-a" }, // ok
+      { deviceId: "chassis-1", slotId: "missing", cardTemplateId: "card-a" }, // fails pre-validation
+    ] }) as { succeeded: number; failed: number; results: { index: number; ok: boolean; error?: string }[] };
+    expect(res.succeeded).toBe(1);
+    expect(res.failed).toBe(1);
+    expect(res.results[1].ok).toBe(false);
+    // Only the successful install pushed undo (the failed item threw before swapCard).
+    expect(useSchematicStore.getState().undoSize).toBe(undoBefore + 1);
+  });
+
+  it("install_card_batch rejects an empty or non-array batch (shape error, not a fake success)", () => {
+    useSchematicStore.setState({ nodes: [], edges: [], customTemplates: [] });
+    expect(() => handlers.install_card_batch({ installs: [] })).toThrow();
+    expect(() => handlers.install_card_batch({} as Record<string, unknown>)).toThrow();
+  });
+
+  it("place_device_in_rack_batch places every device and reports per-item success", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", 480, 44.45), rackDevice("device-2", 480, 44.45)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const res = handlers.place_device_in_rack_batch({ placements: [
+      { deviceId: "device-1", rackId: "rack-1", uPosition: 1 },
+      { deviceId: "device-2", rackId: "rack-1", uPosition: 2 },
+    ] }) as { succeeded: number; failed: number };
+    expect(res).toMatchObject({ succeeded: 2, failed: 0 });
+    const page = useSchematicStore.getState().pages.find((p): p is RackElevationPage => p.type === "rack-elevation")!;
+    expect(page.placements).toHaveLength(2);
+  });
+
+  it("place_device_in_rack_batch is best-effort (occupied U fails) and a failed item pushes no undo step", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", 480, 44.45), rackDevice("device-2", 480, 44.45)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const undoBefore = useSchematicStore.getState().undoSize;
+    const res = handlers.place_device_in_rack_batch({ placements: [
+      { deviceId: "device-1", rackId: "rack-1", uPosition: 1 }, // ok
+      { deviceId: "device-2", rackId: "rack-1", uPosition: 1 }, // fails — U1 now occupied
+    ] }) as { succeeded: number; failed: number; results: { ok: boolean; error?: string }[] };
+    expect(res.succeeded).toBe(1);
+    expect(res.failed).toBe(1);
+    expect(res.results[1].ok).toBe(false);
+    // Only the successful placement pushed undo (the failed item threw before addPlacementSmart).
+    expect(useSchematicStore.getState().undoSize).toBe(undoBefore + 1);
+  });
+});

--- a/src/__tests__/mcpEditing.test.ts
+++ b/src/__tests__/mcpEditing.test.ts
@@ -699,17 +699,205 @@ describe("rack tools (list_racks / create_rack / place_device_in_rack / remove_d
     expect(() => handlers.remove_device_from_rack({ placementId: "pl-404" })).toThrow(/No rack placement/);
   });
 
-  it("place_device_in_rack rejects shelf-only gear (shelf placement is an editor task) and creates nothing", () => {
-    // ~150mm wide -> shelf-only (too small for a direct rack-mount panel).
+  // ~150mm wide -> shelf-only (too small for a direct rack-mount panel).
+  const SHELF = { widthMm: 150, heightMm: 50 };
+
+  it("place_device_in_rack mounts shelf-only gear on an auto-created, bridge-stamped shelf (one undo step)", () => {
     useSchematicStore.setState({
-      nodes: [rackDevice("device-1", 150, 50)],
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm)],
       edges: [],
       pages: [rackPage("rk-1", [rack("rack-1")])],
     });
-    expect(() => handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 })).toThrow(/needs a shelf|too small/);
-    // The bridge never auto-creates a shelf, so nothing is left behind.
+    const res = handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 }) as { placementId: string; shelfId: string; form: string; heightU: number };
+    expect(res.form).toBe("shelf-only");
+    expect(res.heightU).toBe(1);
+    const page = pages()[0];
+    expect(page.accessories).toHaveLength(1);
+    expect(page.accessories[0]).toMatchObject({ id: res.shelfId, type: "shelf", uPosition: 2, bridgeCreatedForPlacementId: res.placementId });
+    expect(page.placements).toHaveLength(1);
+    expect(page.placements[0]).toMatchObject({ id: res.placementId, mountedOnShelfId: res.shelfId });
+    // Shelf + placement are created atomically — one undo removes both.
+    useSchematicStore.getState().undo();
     expect(pages()[0].placements).toHaveLength(0);
     expect(pages()[0].accessories).toHaveLength(0);
+  });
+
+  it("a shelf-only placement is restored as one step by redo (shelf + device come back together)", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const placed = handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 }) as { placementId: string; shelfId: string };
+    useSchematicStore.getState().undo();
+    expect(pages()[0].placements).toHaveLength(0);
+    expect(pages()[0].accessories).toHaveLength(0);
+    useSchematicStore.getState().redo();
+    expect(pages()[0].placements).toHaveLength(1);
+    expect(pages()[0].accessories).toHaveLength(1);
+    expect(pages()[0].accessories[0].bridgeCreatedForPlacementId).toBe(placed.placementId);
+  });
+
+  it("reports a narrow-but-tall shelf-only device's physical heightU consistently with list_racks", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", 150, 88.9)], // ~2U tall, narrow -> shelf-only
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const placed = handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 }) as { form: string; heightU: number };
+    expect(placed.form).toBe("shelf-only");
+    const listed = handlers.list_racks({}) as { pages: { racks: { placements: { heightU: number | null }[] }[] }[] };
+    expect(placed.heightU).toBe(listed.pages[0].racks[0].placements[0].heightU);
+  });
+
+  it("place_device_in_rack_batch places shelf-only gear too (auto-shelf per item)", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm), rackDevice("device-2", FULL_1U.widthMm, FULL_1U.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const res = handlers.place_device_in_rack_batch({ placements: [
+      { deviceId: "device-1", rackId: "rack-1", uPosition: 2 },
+      { deviceId: "device-2", rackId: "rack-1", uPosition: 5 },
+    ] }) as { succeeded: number; failed: number; results: { ok: boolean; result?: { form: string; shelfId?: string } }[] };
+    expect(res.succeeded).toBe(2);
+    expect(res.failed).toBe(0);
+    expect(res.results[0].result?.form).toBe("shelf-only");
+    const shelfId = res.results[0].result?.shelfId;
+    const shelf = pages()[0].accessories.find((a) => a.id === shelfId)!;
+    expect(shelf.bridgeCreatedForPlacementId).toBeDefined();
+  });
+
+  it("place_device_in_rack rejects a shelf-only placement when its 1U is already occupied", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")], [], [
+        { id: "acc-1", rackId: "rack-1", type: "blank-panel", uPosition: 2, heightU: 1, face: "front" },
+      ])],
+    });
+    expect(() => handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 })).toThrow(/occupied|no room/);
+    expect(pages()[0].placements).toHaveLength(0);
+    expect(pages()[0].accessories).toHaveLength(1); // only the pre-existing panel
+  });
+
+  it("remove_device_from_rack cascades the auto-created shelf when unracking its original device", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const placed = handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 }) as { placementId: string; shelfId: string };
+    const res = handlers.remove_device_from_rack({ placementId: placed.placementId }) as { removed: boolean; removedShelfId?: string };
+    expect(res.removed).toBe(true);
+    expect(res.removedShelfId).toBe(placed.shelfId);
+    expect(pages()[0].placements).toHaveLength(0);
+    expect(pages()[0].accessories).toHaveLength(0);
+  });
+
+  it("remove_device_from_rack leaves a user-built (non-bridge) shelf in place", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")], [
+        { id: "pl-1", rackId: "rack-1", deviceNodeId: "device-1", uPosition: 2, face: "front", mountedOnShelfId: "acc-1" },
+      ], [
+        { id: "acc-1", rackId: "rack-1", type: "shelf", uPosition: 2, heightU: 1, face: "front" }, // no provenance
+      ])],
+    });
+    handlers.remove_device_from_rack({ placementId: "pl-1" });
+    expect(pages()[0].placements).toHaveLength(0);
+    expect(pages()[0].accessories).toHaveLength(1); // user shelf untouched
+  });
+
+  it("a user edit (move) of a bridge shelf clears provenance, so a later unrack leaves the shelf", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const placed = handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 }) as { placementId: string; shelfId: string };
+    // User relocates the shelf — adoption. The shelf "looks pristine" (no label/size change) but
+    // updateRackAccessory clears the bridge provenance regardless.
+    useSchematicStore.getState().updateRackAccessory("rk-1", placed.shelfId, { uPosition: 10 });
+    expect(pages()[0].accessories[0].bridgeCreatedForPlacementId).toBeUndefined();
+    const res = handlers.remove_device_from_rack({ placementId: placed.placementId }) as { removedShelfId?: string };
+    expect(res.removedShelfId).toBeUndefined();
+    expect(pages()[0].placements).toHaveLength(0);
+    expect(pages()[0].accessories).toHaveLength(1); // adopted shelf kept
+  });
+
+  it("reuse timeline: a user-added second device adopts the shelf; neither unrack deletes it", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm), rackDevice("device-2", SHELF.widthMm, SHELF.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const a = handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 }) as { placementId: string; shelfId: string };
+    // User drops a 2nd device onto the bridge's shelf — adoption clears provenance.
+    useSchematicStore.getState().addShelfMountedDevice("rk-1", a.shelfId, "device-2");
+    expect(pages()[0].accessories[0].bridgeCreatedForPlacementId).toBeUndefined();
+    // Remove the original device A: shelf + device B stay.
+    handlers.remove_device_from_rack({ placementId: a.placementId });
+    expect(pages()[0].accessories).toHaveLength(1);
+    expect(pages()[0].placements).toHaveLength(1);
+    // Remove device B too: the (now empty) shelf still stays — it's user-adopted.
+    const bPlacement = pages()[0].placements[0];
+    handlers.remove_device_from_rack({ placementId: bPlacement.id });
+    expect(pages()[0].accessories).toHaveLength(1);
+  });
+
+  it("editing the bridge device's placement (e.g. dragging it off the shelf) clears provenance", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    const placed = handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 }) as { placementId: string; shelfId: string };
+    useSchematicStore.getState().updateRackPlacement("rk-1", placed.placementId, { rotated: true });
+    expect(pages()[0].accessories[0].bridgeCreatedForPlacementId).toBeUndefined();
+    const res = handlers.remove_device_from_rack({ placementId: placed.placementId }) as { removedShelfId?: string };
+    expect(res.removedShelfId).toBeUndefined();
+    expect(pages()[0].accessories).toHaveLength(1); // shelf kept (detached/adopted)
+  });
+
+  it("dragging another device ONTO a bridge shelf adopts it (destination clear), so it survives later cleanup", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm), rackDevice("device-2", SHELF.widthMm, SHELF.heightMm)],
+      edges: [],
+      // device-2 starts on its OWN (user) shelf; we'll drag it onto the bridge's shelf.
+      pages: [rackPage("rk-1", [rack("rack-1")], [
+        { id: "pl-2", rackId: "rack-1", deviceNodeId: "device-2", uPosition: 8, face: "front", mountedOnShelfId: "user-shelf" },
+      ], [
+        { id: "user-shelf", rackId: "rack-1", type: "shelf", uPosition: 8, heightU: 1, face: "front" },
+      ])],
+    });
+    const b = handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 }) as { placementId: string; shelfId: string };
+    // Cross-shelf drag: rewire device-2's placement onto the bridge's shelf (destination adoption).
+    useSchematicStore.getState().updateRackPlacement("rk-1", "pl-2", { mountedOnShelfId: b.shelfId, uPosition: 2, face: "front" });
+    const bridgeShelf = pages()[0].accessories.find((a) => a.id === b.shelfId)!;
+    expect(bridgeShelf.bridgeCreatedForPlacementId).toBeUndefined(); // adopted by the user's device
+    // Remove device-2, then the bridge's original device B — the adopted shelf must NOT be deleted.
+    handlers.remove_device_from_rack({ placementId: "pl-2" });
+    const res = handlers.remove_device_from_rack({ placementId: b.placementId }) as { removedShelfId?: string };
+    expect(res.removedShelfId).toBeUndefined();
+    expect(pages()[0].accessories.some((a) => a.id === b.shelfId)).toBe(true);
+  });
+
+  it("duplicating a rack page drops bridge provenance but keeps the shelf-mount link intact", () => {
+    useSchematicStore.setState({
+      nodes: [rackDevice("device-1", SHELF.widthMm, SHELF.heightMm)],
+      edges: [],
+      pages: [rackPage("rk-1", [rack("rack-1")])],
+    });
+    handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-1", uPosition: 2 });
+    const newPageId = useSchematicStore.getState().duplicateRackPage("rk-1");
+    const copy = pages().find((p) => p.id === newPageId)!;
+    expect(copy.accessories).toHaveLength(1);
+    expect(copy.accessories[0].bridgeCreatedForPlacementId).toBeUndefined();
+    // The copied device must point at the COPIED shelf, not the source page's shelf id.
+    expect(copy.placements).toHaveLength(1);
+    expect(copy.placements[0].mountedOnShelfId).toBe(copy.accessories[0].id);
   });
 
   it("list_racks reports rack accessories so a U blocked by a shelf or panel is visible", () => {
@@ -720,9 +908,9 @@ describe("rack tools (list_racks / create_rack / place_device_in_rack / remove_d
         { id: "acc-1", rackId: "rack-1", type: "shelf", uPosition: 4, heightU: 1, face: "front" },
       ])],
     });
-    const listed = handlers.list_racks({}) as { pages: { racks: { accessories: { accessoryId: string; type: string; uPosition: number; heightU: number }[] }[] }[] };
+    const listed = handlers.list_racks({}) as { pages: { racks: { accessories: { accessoryId: string; type: string; uPosition: number; heightU: number; createdByBridge: boolean }[] }[] }[] };
     expect(listed.pages[0].racks[0].accessories).toHaveLength(1);
-    expect(listed.pages[0].racks[0].accessories[0]).toMatchObject({ accessoryId: "acc-1", type: "shelf", uPosition: 4, heightU: 1 });
+    expect(listed.pages[0].racks[0].accessories[0]).toMatchObject({ accessoryId: "acc-1", type: "shelf", uPosition: 4, heightU: 1, createdByBridge: false });
   });
 
   it("create_rack fails on an ambiguous pageId (duplicate page ids) rather than writing to both", () => {

--- a/src/__tests__/mcpEditing.test.ts
+++ b/src/__tests__/mcpEditing.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Store-level tests for the Ship-2 "editing & layout" MCP tools' mutation paths:
+ *   - moveDevice (the move_device tool) — repositions a node in one undo step.
+ *   - onEdgesChange remove (the delete_connection tool) — removes a single edge.
+ *
+ * The store reads editor preferences from localStorage at import time, so we install
+ * a minimal in-memory localStorage and import the store dynamically afterwards. Pure
+ * decision logic (validatePosition / planConnectionRemoval) is covered separately in
+ * mcpValidation.test.ts.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import type { ConnectionEdge, DeviceData, SchematicNode, StubLabelData } from "../types";
+
+class MemStorage {
+  private m = new Map<string, string>();
+  getItem(k: string) { return this.m.has(k) ? this.m.get(k)! : null; }
+  setItem(k: string, v: string) { this.m.set(k, String(v)); }
+  removeItem(k: string) { this.m.delete(k); }
+  clear() { this.m.clear(); }
+  key() { return null; }
+  get length() { return this.m.size; }
+}
+
+let useSchematicStore: typeof import("../store")["useSchematicStore"];
+
+beforeAll(async () => {
+  (globalThis as { localStorage?: unknown }).localStorage = new MemStorage();
+  ({ useSchematicStore } = await import("../store"));
+});
+
+function device(id: string, x: number, y: number): SchematicNode {
+  return {
+    id,
+    type: "device",
+    position: { x, y },
+    data: { label: id, deviceType: "test", ports: [] } as DeviceData,
+  } as SchematicNode;
+}
+
+function edge(id: string, source: string, target: string): ConnectionEdge {
+  return {
+    id,
+    source,
+    target,
+    sourceHandle: `${source}-out`,
+    targetHandle: `${target}-in`,
+    data: { signalType: "hdmi" },
+  } as ConnectionEdge;
+}
+
+function stubLabel(id: string, placed: boolean, userMoved = false): SchematicNode {
+  return {
+    id,
+    type: "stub-label",
+    position: { x: 0, y: 0 },
+    data: {
+      signalType: "hdmi",
+      linkedConnectionId: "cable-1",
+      side: "source",
+      placed,
+      userMoved,
+    } as StubLabelData,
+  } as SchematicNode;
+}
+
+/** A stub-leg edge linking a stub-label node to a device (one end is the stub). */
+function stubLeg(id: string, stubId: string, deviceId: string): ConnectionEdge {
+  return { id, source: stubId, target: deviceId, data: { signalType: "hdmi" } } as ConnectionEdge;
+}
+
+beforeEach(() => {
+  // Seed directly (setState does not push undo), so the next action's snapshot is this state.
+  useSchematicStore.setState({
+    nodes: [device("device-1", 0, 0), device("device-2", 300, 0)],
+    edges: [edge("edge-1", "device-1", "device-2")],
+  });
+});
+
+function posOf(id: string) {
+  return useSchematicStore.getState().nodes.find((n) => n.id === id)!.position;
+}
+
+describe("moveDevice", () => {
+  it("repositions a device and the move is undoable", () => {
+    useSchematicStore.getState().moveDevice("device-1", { x: 120, y: 80 });
+    expect(posOf("device-1")).toEqual({ x: 120, y: 80 });
+    // device-2 untouched
+    expect(posOf("device-2")).toEqual({ x: 300, y: 0 });
+
+    useSchematicStore.getState().undo();
+    expect(posOf("device-1")).toEqual({ x: 0, y: 0 });
+  });
+
+  it("is a no-op for an unknown id (no throw, nothing changed)", () => {
+    useSchematicStore.getState().moveDevice("device-404", { x: 9, y: 9 });
+    expect(useSchematicStore.getState().nodes.map((n) => n.id)).toEqual(["device-1", "device-2"]);
+    expect(posOf("device-1")).toEqual({ x: 0, y: 0 });
+  });
+
+  it("re-anchors auto-placed stub labels connected to the moved device (#182)", () => {
+    useSchematicStore.setState({
+      nodes: [device("device-1", 0, 0), stubLabel("stub-follow", true), stubLabel("stub-user", true, true)],
+      edges: [stubLeg("leg-1", "stub-follow", "device-1"), stubLeg("leg-2", "stub-user", "device-1")],
+    });
+    useSchematicStore.getState().moveDevice("device-1", { x: 200, y: 120 });
+    const nodes = useSchematicStore.getState().nodes;
+    const follow = nodes.find((n) => n.id === "stub-follow")!.data as StubLabelData;
+    const user = nodes.find((n) => n.id === "stub-user")!.data as StubLabelData;
+    expect(follow.placed).toBe(false); // cleared so it re-follows the moved port
+    expect(user.placed).toBe(true); // user-positioned stub left alone
+  });
+});
+
+describe("connection removal (delete_connection path)", () => {
+  it("removes a single connection by id (routes through removeSelected)", () => {
+    useSchematicStore.getState().deleteConnection("edge-1");
+    expect(useSchematicStore.getState().edges).toEqual([]);
+  });
+
+  it("is a no-op for an unknown connection id", () => {
+    useSchematicStore.getState().deleteConnection("edge-404");
+    expect(useSchematicStore.getState().edges.map((e) => e.id)).toEqual(["edge-1"]);
+  });
+
+  it("connection removal is undoable", () => {
+    useSchematicStore.getState().deleteConnection("edge-1");
+    expect(useSchematicStore.getState().edges).toEqual([]);
+    useSchematicStore.getState().undo();
+    expect(useSchematicStore.getState().edges.map((e) => e.id)).toEqual(["edge-1"]);
+  });
+});

--- a/src/__tests__/mcpEditing.test.ts
+++ b/src/__tests__/mcpEditing.test.ts
@@ -111,6 +111,115 @@ describe("moveDevice", () => {
   });
 });
 
+function roomNode(id: string, x: number, y: number, w = 400, h = 300): SchematicNode {
+  return {
+    id,
+    type: "room",
+    position: { x, y },
+    data: { label: id },
+    style: { width: w, height: h },
+  } as SchematicNode;
+}
+
+describe("addRoom (create_room path)", () => {
+  it("creates a room with a custom size", () => {
+    useSchematicStore.setState({ nodes: [], edges: [] });
+    useSchematicStore.getState().addRoom("Conference Room", { x: 500, y: 0 }, { width: 600, height: 400 });
+    const room = useSchematicStore.getState().nodes.find((n) => n.type === "room")!;
+    expect(room).toBeTruthy();
+    expect((room.data as { label: string }).label).toBe("Conference Room");
+    expect(room.style).toMatchObject({ width: 600, height: 400 });
+  });
+
+  it("defaults to 400x300 when no size is given", () => {
+    useSchematicStore.setState({ nodes: [], edges: [] });
+    useSchematicStore.getState().addRoom("R", { x: 500, y: 0 });
+    const room = useSchematicStore.getState().nodes.find((n) => n.type === "room")!;
+    expect(room.style).toMatchObject({ width: 400, height: 300 });
+  });
+
+  it("absorbs a device inside its bounds and the creation is undoable", () => {
+    useSchematicStore.setState({ nodes: [device("device-1", 0, 0)], edges: [] });
+    useSchematicStore.getState().addRoom("R", { x: -10, y: -10 }, { width: 400, height: 300 });
+    const room = useSchematicStore.getState().nodes.find((n) => n.type === "room")!;
+    expect(useSchematicStore.getState().nodes.find((n) => n.id === "device-1")!.parentId).toBe(room.id);
+
+    useSchematicStore.getState().undo();
+    const after = useSchematicStore.getState().nodes;
+    expect(after.some((n) => n.type === "room")).toBe(false);
+    expect(after.find((n) => n.id === "device-1")!.parentId).toBeUndefined();
+  });
+});
+
+describe("placeDeviceInRoom (place_device_in_room path)", () => {
+  it("places a device in the room with a room-relative position (undoable)", () => {
+    useSchematicStore.setState({ nodes: [roomNode("room-1", 100, 100), device("device-1", 0, 0)], edges: [] });
+    const placed = useSchematicStore.getState().placeDeviceInRoom("device-1", "room-1", { x: 20, y: 30 });
+    expect(placed).toBe(true);
+    const dev = useSchematicStore.getState().nodes.find((n) => n.id === "device-1")!;
+    expect(dev.parentId).toBe("room-1");
+    expect(dev.position).toEqual({ x: 20, y: 30 }); // relative to the room's top-left
+
+    useSchematicStore.getState().undo();
+    const back = useSchematicStore.getState().nodes.find((n) => n.id === "device-1")!;
+    expect(back.parentId).toBeUndefined();
+    expect(back.position).toEqual({ x: 0, y: 0 });
+  });
+
+  it("changes nothing and returns false when the position would fall outside the room", () => {
+    useSchematicStore.setState({ nodes: [roomNode("room-1", 100, 100, 400, 300), device("device-1", 0, 0)], edges: [] });
+    const snapshot = JSON.stringify(useSchematicStore.getState().nodes);
+    const placed = useSchematicStore.getState().placeDeviceInRoom("device-1", "room-1", { x: 9999, y: 9999 });
+    expect(placed).toBe(false);
+    // Nothing mutated at all — device stays top-level at its original position.
+    expect(JSON.stringify(useSchematicStore.getState().nodes)).toBe(snapshot);
+  });
+
+  it("returns false (no false success) when the device is ALREADY in the room but the new position is invalid", () => {
+    // device-1 is already a child of room-1; a reject must not look like a success just
+    // because parentId is still room-1.
+    useSchematicStore.setState({
+      nodes: [roomNode("room-1", 100, 100, 400, 300), { ...device("device-1", 10, 10), parentId: "room-1" } as SchematicNode],
+      edges: [],
+    });
+    const snapshot = JSON.stringify(useSchematicStore.getState().nodes);
+    const placed = useSchematicStore.getState().placeDeviceInRoom("device-1", "room-1", { x: 9999, y: 9999 });
+    expect(placed).toBe(false);
+    expect(JSON.stringify(useSchematicStore.getState().nodes)).toBe(snapshot);
+  });
+
+  it("returns true with no mutation and no empty undo step when already at that exact spot", () => {
+    useSchematicStore.setState({
+      nodes: [roomNode("room-1", 100, 100, 400, 300), { ...device("device-1", 20, 30), parentId: "room-1" } as SchematicNode],
+      edges: [],
+    });
+    const undoBefore = useSchematicStore.getState().undoSize;
+    const snapshot = JSON.stringify(useSchematicStore.getState().nodes);
+    const placed = useSchematicStore.getState().placeDeviceInRoom("device-1", "room-1", { x: 20, y: 30 });
+    expect(placed).toBe(true);
+    expect(JSON.stringify(useSchematicStore.getState().nodes)).toBe(snapshot); // unchanged
+    expect(useSchematicStore.getState().undoSize).toBe(undoBefore); // no empty undo step pushed
+  });
+
+  it("returns false and is a no-op when the target id is not a room", () => {
+    useSchematicStore.setState({ nodes: [device("device-1", 0, 0), device("device-2", 300, 0)], edges: [] });
+    const snapshot = JSON.stringify(useSchematicStore.getState().nodes);
+    const placed = useSchematicStore.getState().placeDeviceInRoom("device-1", "device-2", { x: 10, y: 10 });
+    expect(placed).toBe(false);
+    expect(JSON.stringify(useSchematicStore.getState().nodes)).toBe(snapshot);
+  });
+
+  it("re-anchors connected auto-placed stub labels when placing", () => {
+    useSchematicStore.setState({
+      nodes: [roomNode("room-1", 100, 100), device("device-1", 0, 0), stubLabel("stub-follow", true)],
+      edges: [stubLeg("leg-1", "stub-follow", "device-1")],
+    });
+    useSchematicStore.getState().placeDeviceInRoom("device-1", "room-1", { x: 20, y: 30 });
+    const follow = useSchematicStore.getState().nodes.find((n) => n.id === "stub-follow")!.data as StubLabelData;
+    expect(follow.placed).toBe(false);
+  });
+});
+
 describe("connection removal (delete_connection path)", () => {
   it("removes a single connection by id (routes through removeSelected)", () => {
     useSchematicStore.getState().deleteConnection("edge-1");

--- a/src/__tests__/mcpEditing.test.ts
+++ b/src/__tests__/mcpEditing.test.ts
@@ -755,3 +755,71 @@ describe("rack tools (list_racks / create_rack / place_device_in_rack / remove_d
     expect(() => handlers.place_device_in_rack({ deviceId: "device-1", rackId: "rack-dup", uPosition: 1 })).toThrow(/ambiguous/);
   });
 });
+
+describe("notes & rooms read + notes CRUD (update_note / delete_note)", () => {
+  function noteNode(id: string, html: string, x = 0, y = 0): SchematicNode {
+    return { id, type: "note", position: { x, y }, data: { html } as NoteData } as SchematicNode;
+  }
+  function noteHtmlOf(id: string) {
+    return (useSchematicStore.getState().nodes.find((n) => n.id === id)!.data as NoteData).html;
+  }
+
+  it("get_schematic reports rooms and notes alongside devices", () => {
+    useSchematicStore.setState({
+      nodes: [device("device-1", 0, 0), roomNode("room-1", 100, 50, 500, 350), noteNode("note-1", "hello<br>world", 10, 20)],
+      edges: [],
+    });
+    const schem = handlers.get_schematic({}) as {
+      roomCount: number;
+      noteCount: number;
+      rooms: { roomId: string; label: string; width: number; height: number; parentId?: string }[];
+      notes: { noteId: string; text: string; position: { x: number; y: number }; parentId?: string }[];
+    };
+    expect(schem.roomCount).toBe(1);
+    expect(schem.noteCount).toBe(1);
+    expect(schem.rooms[0]).toMatchObject({ roomId: "room-1", label: "room-1", width: 500, height: 350 });
+    expect(schem.notes[0]).toMatchObject({ noteId: "note-1", text: "hello\nworld", position: { x: 10, y: 20 } });
+  });
+
+  it("get_schematic reports a room's measured size when it differs from style", () => {
+    // React Flow's live `measured` supersedes `style`; report what the editor uses.
+    const room = { id: "room-1", type: "room", position: { x: 0, y: 0 }, data: { label: "R" }, style: { width: 400, height: 300 }, measured: { width: 640, height: 480 } } as unknown as SchematicNode;
+    useSchematicStore.setState({ nodes: [room], edges: [] });
+    const schem = handlers.get_schematic({}) as { rooms: { width: number; height: number }[] };
+    expect(schem.rooms[0]).toMatchObject({ width: 640, height: 480 });
+  });
+
+  it("update_note replaces the note's content (escaped) and is undoable", () => {
+    useSchematicStore.setState({ nodes: [noteNode("note-1", "old", 0, 0)], edges: [] });
+    const res = handlers.update_note({ noteId: "note-1", text: "new\n<b>" }) as { changed: boolean };
+    expect(res.changed).toBe(true);
+    expect(noteHtmlOf("note-1")).toBe("new<br>&lt;b&gt;");
+    useSchematicStore.getState().undo();
+    expect(noteHtmlOf("note-1")).toBe("old");
+  });
+
+  it("update_note is a no-op (no undo step) when the text is unchanged", () => {
+    useSchematicStore.setState({ nodes: [noteNode("note-1", "same", 0, 0)], edges: [] });
+    const undoBefore = useSchematicStore.getState().undoSize;
+    const res = handlers.update_note({ noteId: "note-1", text: "same" }) as { changed: boolean };
+    expect(res.changed).toBe(false);
+    expect(useSchematicStore.getState().undoSize).toBe(undoBefore); // no empty undo step pushed
+  });
+
+  it("update_note rejects empty text, a missing note, and a non-note target", () => {
+    useSchematicStore.setState({ nodes: [noteNode("note-1", "x", 0, 0), device("device-1", 0, 0)], edges: [] });
+    expect(() => handlers.update_note({ noteId: "note-1", text: "   " })).toThrow(/text is required/);
+    expect(() => handlers.update_note({ noteId: "missing", text: "hi" })).toThrow(/No note found/);
+    expect(() => handlers.update_note({ noteId: "device-1", text: "hi" })).toThrow(/not a note/);
+  });
+
+  it("delete_note removes the note (undoable) and rejects a non-note", () => {
+    useSchematicStore.setState({ nodes: [noteNode("note-1", "bye", 0, 0), device("device-1", 0, 0)], edges: [] });
+    const res = handlers.delete_note({ noteId: "note-1" }) as { deleted: boolean };
+    expect(res.deleted).toBe(true);
+    expect(useSchematicStore.getState().nodes.some((n) => n.id === "note-1")).toBe(false);
+    useSchematicStore.getState().undo();
+    expect(useSchematicStore.getState().nodes.some((n) => n.id === "note-1")).toBe(true);
+    expect(() => handlers.delete_note({ noteId: "device-1" })).toThrow(/not a note/);
+  });
+});

--- a/src/__tests__/mcpValidation.test.ts
+++ b/src/__tests__/mcpValidation.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { classifyDeviceProperties, resolveHandleFromCandidates } from "../mcp/validation";
+import {
+  classifyDeviceProperties,
+  resolveHandleFromCandidates,
+  validatePosition,
+  planConnectionRemoval,
+} from "../mcp/validation";
 
 describe("classifyDeviceProperties", () => {
   it("routes label and shortName to their dedicated buckets", () => {
@@ -73,5 +78,47 @@ describe("resolveHandleFromCandidates", () => {
     const r = resolveHandleFromCandidates(["lan-in", "lan-out"], "lan", "rear");
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toMatch(/Invalid face/);
+  });
+});
+
+describe("validatePosition", () => {
+  it("accepts finite integers, floats, zero and negatives", () => {
+    expect(validatePosition(100, 50)).toEqual({ ok: true, position: { x: 100, y: 50 } });
+    expect(validatePosition(0, 0)).toEqual({ ok: true, position: { x: 0, y: 0 } });
+    expect(validatePosition(-12.5, 33.25)).toEqual({ ok: true, position: { x: -12.5, y: 33.25 } });
+  });
+
+  it("rejects missing, NaN, Infinity and non-number values", () => {
+    for (const [x, y] of [
+      [undefined, 0],
+      [0, undefined],
+      [NaN, 0],
+      [0, Infinity],
+      ["100", 0],
+      [0, null],
+      [{}, 0],
+    ] as [unknown, unknown][]) {
+      expect(validatePosition(x, y).ok).toBe(false);
+    }
+  });
+});
+
+describe("planConnectionRemoval", () => {
+  it("removes a plain connection by id", () => {
+    const edges = [{ id: "edge-1" }, { id: "edge-2" }];
+    expect(planConnectionRemoval(edges, "edge-1")).toEqual({ ok: true, removeId: "edge-1" });
+  });
+
+  it("errors when the connection id is not found", () => {
+    const r = planConnectionRemoval([{ id: "edge-1" }], "edge-9");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/No connection found/);
+  });
+
+  it("rejects a stubbed (linked) connection rather than orphaning its partner leg", () => {
+    const edges = [{ id: "edge-1", data: { linkedConnectionId: "cable-7" } }];
+    const r = planConnectionRemoval(edges, "edge-1");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/stubbed/);
   });
 });

--- a/src/__tests__/mcpValidation.test.ts
+++ b/src/__tests__/mcpValidation.test.ts
@@ -8,6 +8,9 @@ import {
   runBatch,
   noteTextToHtml,
   validateCardForSlot,
+  validateUPosition,
+  validateRackFace,
+  validateRackSpec,
 } from "../mcp/validation";
 
 describe("classifyDeviceProperties", () => {
@@ -245,5 +248,65 @@ describe("runBatch", () => {
     expect(r.results[1].ok).toBe(false);
     expect(r.results[1].error).toMatch(/boom on 2/);
     expect(r.results[2]).toEqual({ index: 2, ok: true, result: 30 });
+  });
+});
+
+describe("validateUPosition", () => {
+  it("accepts a whole number >= 1", () => {
+    expect(validateUPosition(1)).toEqual({ ok: true, u: 1 });
+    expect(validateUPosition(42)).toEqual({ ok: true, u: 42 });
+  });
+
+  it("rejects zero, negatives, fractions and non-numbers", () => {
+    for (const bad of [0, -1, 1.5, "3", NaN, undefined]) {
+      expect(validateUPosition(bad as unknown).ok).toBe(false);
+    }
+  });
+});
+
+describe("validateRackFace", () => {
+  it("defaults to front when omitted", () => {
+    expect(validateRackFace(undefined)).toEqual({ ok: true, face: "front" });
+  });
+
+  it("accepts front and rear", () => {
+    expect(validateRackFace("front")).toEqual({ ok: true, face: "front" });
+    expect(validateRackFace("rear")).toEqual({ ok: true, face: "rear" });
+  });
+
+  it("rejects any other value", () => {
+    expect(validateRackFace("side").ok).toBe(false);
+    expect(validateRackFace("top").ok).toBe(false);
+  });
+});
+
+describe("validateRackSpec", () => {
+  it("applies defaults when all fields are omitted", () => {
+    expect(validateRackSpec(undefined, undefined, undefined)).toEqual({
+      ok: true,
+      rackType: "floor-19",
+      heightU: 42,
+      depthMm: 600,
+    });
+  });
+
+  it("clamps heightU and depthMm to the editor's ranges and rounds", () => {
+    const tall = validateRackSpec("floor-19", 100, 5000);
+    expect(tall).toEqual({ ok: true, rackType: "floor-19", heightU: 60, depthMm: 2000 });
+    const tiny = validateRackSpec("wall-mount", 1, 50);
+    expect(tiny).toEqual({ ok: true, rackType: "wall-mount", heightU: 2, depthMm: 100 });
+    const rounded = validateRackSpec("desktop", 8.4, 612.7);
+    expect(rounded).toEqual({ ok: true, rackType: "desktop", heightU: 8, depthMm: 613 });
+  });
+
+  it("rejects an unknown rackType", () => {
+    const r = validateRackSpec("server-rack", 42, 600);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/rackType must be one of/);
+  });
+
+  it("rejects a supplied but non-numeric heightU or depthMm", () => {
+    expect(validateRackSpec("floor-19", NaN, 600).ok).toBe(false);
+    expect(validateRackSpec("floor-19", 42, Infinity).ok).toBe(false);
   });
 });

--- a/src/__tests__/mcpValidation.test.ts
+++ b/src/__tests__/mcpValidation.test.ts
@@ -4,6 +4,7 @@ import {
   resolveHandleFromCandidates,
   validatePosition,
   planConnectionRemoval,
+  runBatch,
 } from "../mcp/validation";
 
 describe("classifyDeviceProperties", () => {
@@ -120,5 +121,43 @@ describe("planConnectionRemoval", () => {
     const r = planConnectionRemoval(edges, "edge-1");
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toMatch(/stubbed/);
+  });
+});
+
+describe("runBatch", () => {
+  const double = (n: number) => n * 2;
+
+  it("rejects a non-array, an empty array, and an over-cap array", () => {
+    expect(runBatch("nope" as unknown, 10, double).ok).toBe(false);
+    expect(runBatch([], 10, double).ok).toBe(false);
+    expect(runBatch([1, 2, 3], 2, double).ok).toBe(false);
+  });
+
+  it("applies fn to every item and reports per-item success with index order", () => {
+    const r = runBatch([1, 2, 3], 10, double);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.succeeded).toBe(3);
+    expect(r.failed).toBe(0);
+    expect(r.results).toEqual([
+      { index: 0, ok: true, result: 2 },
+      { index: 1, ok: true, result: 4 },
+      { index: 2, ok: true, result: 6 },
+    ]);
+  });
+
+  it("is best-effort: a throwing item is captured, the rest still run", () => {
+    const r = runBatch([1, 2, 3], 10, (n: number) => {
+      if (n === 2) throw new Error("boom on 2");
+      return n * 10;
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.succeeded).toBe(2);
+    expect(r.failed).toBe(1);
+    expect(r.results[0]).toEqual({ index: 0, ok: true, result: 10 });
+    expect(r.results[1].ok).toBe(false);
+    expect(r.results[1].error).toMatch(/boom on 2/);
+    expect(r.results[2]).toEqual({ index: 2, ok: true, result: 30 });
   });
 });

--- a/src/__tests__/mcpValidation.test.ts
+++ b/src/__tests__/mcpValidation.test.ts
@@ -6,6 +6,7 @@ import {
   validateRoomSize,
   planConnectionRemoval,
   runBatch,
+  noteTextToHtml,
 } from "../mcp/validation";
 
 describe("classifyDeviceProperties", () => {
@@ -152,6 +153,35 @@ describe("planConnectionRemoval", () => {
     const r = planConnectionRemoval(edges, "edge-1");
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toMatch(/stubbed/);
+  });
+});
+
+describe("noteTextToHtml", () => {
+  it("leaves plain text unchanged", () => {
+    expect(noteTextToHtml("Main rack")).toBe("Main rack");
+  });
+
+  it("entity-escapes &, < and > so text can never become markup", () => {
+    expect(noteTextToHtml("a < b && c > d")).toBe("a &lt; b &amp;&amp; c &gt; d");
+    expect(noteTextToHtml('<script>alert(1)</script>')).toBe(
+      "&lt;script&gt;alert(1)&lt;/script&gt;",
+    );
+  });
+
+  it("escapes the ampersand before the angle brackets (no double-encoding)", () => {
+    // If & were escaped after <, the "&lt;" it produces would be re-escaped to
+    // "&amp;lt;". Order matters; this guards it.
+    expect(noteTextToHtml("<")).toBe("&lt;");
+  });
+
+  it("converts newlines to <br>, normalizing CRLF and lone CR first", () => {
+    expect(noteTextToHtml("line1\nline2")).toBe("line1<br>line2");
+    expect(noteTextToHtml("line1\r\nline2")).toBe("line1<br>line2");
+    expect(noteTextToHtml("line1\rline2")).toBe("line1<br>line2");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(noteTextToHtml("")).toBe("");
   });
 });
 

--- a/src/__tests__/mcpValidation.test.ts
+++ b/src/__tests__/mcpValidation.test.ts
@@ -3,6 +3,7 @@ import {
   classifyDeviceProperties,
   resolveHandleFromCandidates,
   validatePosition,
+  validateRoomSize,
   planConnectionRemoval,
   runBatch,
 } from "../mcp/validation";
@@ -101,6 +102,36 @@ describe("validatePosition", () => {
     ] as [unknown, unknown][]) {
       expect(validatePosition(x, y).ok).toBe(false);
     }
+  });
+});
+
+describe("validateRoomSize", () => {
+  it("accepts omitting both (caller uses the default)", () => {
+    expect(validateRoomSize(undefined, undefined)).toEqual({ ok: true, size: undefined });
+  });
+
+  it("accepts a size at or above the editor minimums", () => {
+    expect(validateRoomSize(200, 150)).toEqual({ ok: true, size: { width: 200, height: 150 } });
+    expect(validateRoomSize(800, 600)).toEqual({ ok: true, size: { width: 800, height: 600 } });
+  });
+
+  it("rejects a width below the minimum", () => {
+    expect(validateRoomSize(199, 300).ok).toBe(false);
+  });
+
+  it("rejects a height below the minimum", () => {
+    expect(validateRoomSize(400, 149).ok).toBe(false);
+  });
+
+  it("rejects a partial size (only one dimension given)", () => {
+    expect(validateRoomSize(400, undefined).ok).toBe(false);
+    expect(validateRoomSize(undefined, 300).ok).toBe(false);
+  });
+
+  it("rejects non-finite values", () => {
+    expect(validateRoomSize(NaN, 300).ok).toBe(false);
+    expect(validateRoomSize(400, Infinity).ok).toBe(false);
+    expect(validateRoomSize("400", "300").ok).toBe(false);
   });
 });
 

--- a/src/__tests__/mcpValidation.test.ts
+++ b/src/__tests__/mcpValidation.test.ts
@@ -7,6 +7,7 @@ import {
   planConnectionRemoval,
   runBatch,
   noteTextToHtml,
+  validateCardForSlot,
 } from "../mcp/validation";
 
 describe("classifyDeviceProperties", () => {
@@ -182,6 +183,30 @@ describe("noteTextToHtml", () => {
 
   it("returns an empty string for empty input", () => {
     expect(noteTextToHtml("")).toBe("");
+  });
+});
+
+describe("validateCardForSlot", () => {
+  it("accepts a card whose slot family matches the slot", () => {
+    expect(validateCardForSlot("yamaha-my", "yamaha-my")).toEqual({ ok: true });
+  });
+
+  it("rejects a template that is not an expansion card (no slot family)", () => {
+    const r = validateCardForSlot("yamaha-my", undefined);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/not an expansion card/);
+  });
+
+  it("rejects a mismatched slot family", () => {
+    const r = validateCardForSlot("yamaha-my", "disguise-vfc");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/does not fit/);
+  });
+
+  it("rejects when the slot itself has no slot family", () => {
+    const r = validateCardForSlot(undefined, "yamaha-my");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/no slot family/);
   });
 });
 

--- a/src/__tests__/mcpValidation.test.ts
+++ b/src/__tests__/mcpValidation.test.ts
@@ -7,6 +7,7 @@ import {
   planConnectionRemoval,
   runBatch,
   noteTextToHtml,
+  noteHtmlToText,
   validateCardForSlot,
   validateUPosition,
   validateRackFace,
@@ -308,5 +309,36 @@ describe("validateRackSpec", () => {
   it("rejects a supplied but non-numeric heightU or depthMm", () => {
     expect(validateRackSpec("floor-19", NaN, 600).ok).toBe(false);
     expect(validateRackSpec("floor-19", 42, Infinity).ok).toBe(false);
+  });
+});
+
+describe("noteHtmlToText", () => {
+  it("round-trips text put through noteTextToHtml", () => {
+    const text = "Head end\nrack 2 & 3";
+    expect(noteHtmlToText(noteTextToHtml(text))).toBe(text);
+  });
+
+  it("turns <br> into newlines and unescapes entities", () => {
+    expect(noteHtmlToText("a<br>b")).toBe("a\nb");
+    expect(noteHtmlToText("x &amp; y &lt; z")).toBe("x & y < z");
+  });
+
+  it("keeps block structure (div/p/li) as line breaks rather than merging text", () => {
+    expect(noteHtmlToText("<div>A</div><div>B</div>")).toBe("A\nB");
+    expect(noteHtmlToText("first<div>second</div>")).toBe("first\nsecond");
+    expect(noteHtmlToText("<ul><li>one</li><li>two</li></ul>")).toBe("one\ntwo");
+  });
+
+  it("strips inline formatting tags but keeps their text", () => {
+    expect(noteHtmlToText("<b>bold</b> and <i>italic</i>")).toBe("bold and italic");
+  });
+
+  it("does not double-unescape (&amp;lt; stays literal &lt;)", () => {
+    expect(noteHtmlToText("a &amp;lt; b")).toBe("a &lt; b");
+  });
+
+  it("returns empty string for empty/whitespace html", () => {
+    expect(noteHtmlToText("")).toBe("");
+    expect(noteHtmlToText("<div></div>")).toBe("");
   });
 });

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -25,7 +25,8 @@ export const PROTOCOL_VERSION = 1;
  *  "annotations" tool (add_note), the three Ship-6 "slots / modular chassis"
  *  tools (list_slot_cards, install_card, remove_card), and the four Ship-7
  *  "racks / rack elevation" tools (list_racks, create_rack, place_device_in_rack,
- *  remove_device_from_rack). */
+ *  remove_device_from_rack), and the two Ship-8 "notes" tools (update_note,
+ *  delete_note — get_schematic also now reports rooms + notes). */
 export type CommandType =
   | "get_schematic"
   | "list_devices"
@@ -48,7 +49,9 @@ export type CommandType =
   | "list_racks"
   | "create_rack"
   | "place_device_in_rack"
-  | "remove_device_from_rack";
+  | "remove_device_from_rack"
+  | "update_note"
+  | "delete_note";
 
 /** Max items accepted by a single batch tool call (input arrives over the bridge,
  *  so it is capped). The mcp-server tool schemas mirror this as `maxItems`. */
@@ -270,6 +273,20 @@ export interface RemoveDeviceFromRackParams {
   /** The placement id to remove, from list_racks. The device itself stays on the
    *  schematic — only its rack placement is removed. */
   placementId: string;
+}
+
+export interface UpdateNoteParams {
+  /** The note id, from get_schematic's `notes`. */
+  noteId: string;
+  /** New plain text for the note. HTML-escaped on the way in (the note renders as
+   *  HTML), so it always shows literally; newlines become line breaks. Replaces the
+   *  note's content (a note with rich editor formatting becomes plain text). */
+  text: string;
+}
+
+export interface DeleteNoteParams {
+  /** The note id to delete, from get_schematic's `notes`. */
+  noteId: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -22,8 +22,10 @@ export const PROTOCOL_VERSION = 1;
  *  "editing & layout" tools (move_device, delete_connection), the two Ship-3
  *  "batch" tools (add_devices, connect_devices_batch), the two Ship-4
  *  "rooms" tools (create_room, place_device_in_room), the Ship-5
- *  "annotations" tool (add_note), and the three Ship-6 "slots / modular chassis"
- *  tools (list_slot_cards, install_card, remove_card). */
+ *  "annotations" tool (add_note), the three Ship-6 "slots / modular chassis"
+ *  tools (list_slot_cards, install_card, remove_card), and the four Ship-7
+ *  "racks / rack elevation" tools (list_racks, create_rack, place_device_in_rack,
+ *  remove_device_from_rack). */
 export type CommandType =
   | "get_schematic"
   | "list_devices"
@@ -42,7 +44,11 @@ export type CommandType =
   | "add_note"
   | "list_slot_cards"
   | "install_card"
-  | "remove_card";
+  | "remove_card"
+  | "list_racks"
+  | "create_rack"
+  | "place_device_in_rack"
+  | "remove_device_from_rack";
 
 /** Max items accepted by a single batch tool call (input arrives over the bridge,
  *  so it is capped). The mcp-server tool schemas mirror this as `maxItems`. */
@@ -51,6 +57,11 @@ export const MAX_BATCH_ITEMS = 100;
 /** Which two-sided face of a port to wire. Required only for bidirectional ports
  *  (`in`/`out`) and passthrough ports (`rear`/`front`); ignored for plain ports. */
 export type PortFace = "in" | "out" | "rear" | "front";
+
+/** The rack enclosure types, mirroring `RackType` in `src/types.ts`. Kept here as the
+ *  single source the bridge validates against (create_rack); the server tool schema
+ *  mirrors the same five values. */
+export const RACK_TYPES = ["floor-19", "wall-mount", "desktop", "open-2post", "open-4post"] as const;
 
 // ---------------------------------------------------------------------------
 // App -> server: handshake. The app proves it is the real editor (token) and the
@@ -223,6 +234,42 @@ export interface RemoveCardParams {
   deviceId: string;
   /** The (filled) slot's id, from get_device's `slots`. */
   slotId: string;
+}
+
+export interface CreateRackParams {
+  /** Display name for the rack. Defaults to "Rack". */
+  label?: string;
+  /** Rack height in rack units. Clamped to the editor's range [2, 60]. Default 42. */
+  heightU?: number;
+  /** One of RACK_TYPES. Default "floor-19". */
+  rackType?: string;
+  /** Rack depth in mm. Clamped to the editor's range [100, 2000]. Default 600. */
+  depthMm?: number;
+  /** Target rack-elevation page id (from list_racks). When omitted, a new rack page
+   *  is created and the rack is added to it. */
+  pageId?: string;
+  /** Name for the new rack page, used only when `pageId` is omitted. Default
+   *  "Rack Elevation". */
+  pageLabel?: string;
+}
+
+export interface PlaceDeviceInRackParams {
+  /** The device (from get_schematic) to mount in the rack. */
+  deviceId: string;
+  /** The target rack's id, from list_racks. Its page is derived from this id. */
+  rackId: string;
+  /** Bottom U position (1-based, counted from the bottom). The device's height in U
+   *  is inferred from its dimensions; the call fails if the span is occupied or out of
+   *  the rack's bounds. */
+  uPosition: number;
+  /** Which face to mount on; defaults to "front". "rear" is rejected on 2-post racks. */
+  face?: "front" | "rear";
+}
+
+export interface RemoveDeviceFromRackParams {
+  /** The placement id to remove, from list_racks. The device itself stays on the
+   *  schematic — only its rack placement is removed. */
+  placementId: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -21,8 +21,9 @@ export const PROTOCOL_VERSION = 1;
 /** The bridge tools: the eight Ship-1 "working core" tools, the two Ship-2
  *  "editing & layout" tools (move_device, delete_connection), the two Ship-3
  *  "batch" tools (add_devices, connect_devices_batch), the two Ship-4
- *  "rooms" tools (create_room, place_device_in_room), and the Ship-5
- *  "annotations" tool (add_note). */
+ *  "rooms" tools (create_room, place_device_in_room), the Ship-5
+ *  "annotations" tool (add_note), and the three Ship-6 "slots / modular chassis"
+ *  tools (list_slot_cards, install_card, remove_card). */
 export type CommandType =
   | "get_schematic"
   | "list_devices"
@@ -38,7 +39,10 @@ export type CommandType =
   | "connect_devices_batch"
   | "create_room"
   | "place_device_in_room"
-  | "add_note";
+  | "add_note"
+  | "list_slot_cards"
+  | "install_card"
+  | "remove_card";
 
 /** Max items accepted by a single batch tool call (input arrives over the bridge,
  *  so it is capped). The mcp-server tool schemas mirror this as `maxItems`. */
@@ -196,6 +200,29 @@ export interface AddNoteParams {
   /** Note top-left position in canvas coordinates. */
   x: number;
   y: number;
+}
+
+export interface ListSlotCardsParams {
+  /** The modular device (chassis) whose slot you want cards for. */
+  deviceId: string;
+  /** A slot id from get_device's `slots`. */
+  slotId: string;
+}
+
+export interface InstallCardParams {
+  /** The modular device (chassis) to install the card into. */
+  deviceId: string;
+  /** The (empty) slot's id, from get_device's `slots`. */
+  slotId: string;
+  /** A card templateId from list_slot_cards. Its slot family must match the slot's. */
+  cardTemplateId: string;
+}
+
+export interface RemoveCardParams {
+  /** The modular device (chassis) to remove a card from. */
+  deviceId: string;
+  /** The (filled) slot's id, from get_device's `slots`. */
+  slotId: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -19,8 +19,9 @@ export const DEFAULT_BRIDGE_PORT = 8765;
 export const PROTOCOL_VERSION = 1;
 
 /** The bridge tools: the eight Ship-1 "working core" tools, the two Ship-2
- *  "editing & layout" tools (move_device, delete_connection), and the two Ship-3
- *  "batch" tools (add_devices, connect_devices_batch). */
+ *  "editing & layout" tools (move_device, delete_connection), the two Ship-3
+ *  "batch" tools (add_devices, connect_devices_batch), and the two Ship-4
+ *  "rooms" tools (create_room, place_device_in_room). */
 export type CommandType =
   | "get_schematic"
   | "list_devices"
@@ -33,7 +34,9 @@ export type CommandType =
   | "move_device"
   | "delete_connection"
   | "add_devices"
-  | "connect_devices_batch";
+  | "connect_devices_batch"
+  | "create_room"
+  | "place_device_in_room";
 
 /** Max items accepted by a single batch tool call (input arrives over the bridge,
  *  so it is capped). The mcp-server tool schemas mirror this as `maxItems`. */
@@ -159,6 +162,29 @@ export interface ConnectDevicesBatchParams {
   /** Connections to make in one call; each is attempted independently in array
    *  order (best-effort), so an earlier connection can affect a later one. */
   connections: ConnectDevicesParams[];
+}
+
+export interface CreateRoomParams {
+  /** The room's name, shown on the canvas. */
+  label: string;
+  /** Room top-left position in canvas coordinates. */
+  x: number;
+  y: number;
+  /** Optional room size; both are required together when given. Defaults to
+   *  400x300. Minimums mirror the editor: width >= 200, height >= 150. */
+  width?: number;
+  height?: number;
+}
+
+export interface PlaceDeviceInRoomParams {
+  /** The device to place inside the room. */
+  deviceId: string;
+  /** The target room (container) id from get_schematic / create_room. */
+  roomId: string;
+  /** Position relative to the room's top-left corner; defaults to (16,16). The
+   *  device's center must land inside the room or the call fails (nothing changes). */
+  x?: number;
+  y?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -18,7 +18,8 @@ export const DEFAULT_BRIDGE_PORT = 8765;
  *  refuses to pair instead of misbehaving. */
 export const PROTOCOL_VERSION = 1;
 
-/** The eight tools exposed in Ship 1 ("working core"). */
+/** The bridge tools: the eight Ship-1 "working core" tools plus the two Ship-2
+ *  "editing & layout" tools (move_device, delete_connection). */
 export type CommandType =
   | "get_schematic"
   | "list_devices"
@@ -27,7 +28,9 @@ export type CommandType =
   | "add_device"
   | "set_device_property"
   | "connect_devices"
-  | "delete_device";
+  | "delete_device"
+  | "move_device"
+  | "delete_connection";
 
 /** Which two-sided face of a port to wire. Required only for bidirectional ports
  *  (`in`/`out`) and passthrough ports (`rear`/`front`); ignored for plain ports. */
@@ -124,6 +127,20 @@ export interface SearchTemplatesParams {
 
 export interface DeleteDeviceParams {
   nodeId: string;
+}
+
+export interface MoveDeviceParams {
+  nodeId: string;
+  /** New position in the SAME coordinate space get_device/get_schematic report for
+   *  this device: canvas coordinates for a top-level device, or coordinates relative
+   *  to its room/rack when the device has a parentId. Does not change containment. */
+  x: number;
+  y: number;
+}
+
+export interface DeleteConnectionParams {
+  /** The connection (edge) id from get_schematic / connect_devices. */
+  connectionId: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -25,8 +25,9 @@ export const PROTOCOL_VERSION = 1;
  *  "annotations" tool (add_note), the three Ship-6 "slots / modular chassis"
  *  tools (list_slot_cards, install_card, remove_card), and the four Ship-7
  *  "racks / rack elevation" tools (list_racks, create_rack, place_device_in_rack,
- *  remove_device_from_rack), and the two Ship-8 "notes" tools (update_note,
- *  delete_note — get_schematic also now reports rooms + notes). */
+ *  remove_device_from_rack), the two Ship-8 "notes" tools (update_note,
+ *  delete_note — get_schematic also now reports rooms + notes), and the two Ship-9
+ *  "batch structural" tools (install_card_batch, place_device_in_rack_batch). */
 export type CommandType =
   | "get_schematic"
   | "list_devices"
@@ -51,7 +52,9 @@ export type CommandType =
   | "place_device_in_rack"
   | "remove_device_from_rack"
   | "update_note"
-  | "delete_note";
+  | "delete_note"
+  | "install_card_batch"
+  | "place_device_in_rack_batch";
 
 /** Max items accepted by a single batch tool call (input arrives over the bridge,
  *  so it is capped). The mcp-server tool schemas mirror this as `maxItems`. */
@@ -287,6 +290,22 @@ export interface UpdateNoteParams {
 export interface DeleteNoteParams {
   /** The note id to delete, from get_schematic's `notes`. */
   noteId: string;
+}
+
+export interface InstallCardBatchParams {
+  /** Cards to install in one call; each is attempted independently in array order
+   *  (best-effort). Order matters: installing a card that itself adds sub-slots can make
+   *  a later install into one of those sub-slots valid, and two installs targeting the
+   *  same slot leave only the first applied (the second fails — the slot is now filled). */
+  installs: InstallCardParams[];
+}
+
+export interface PlaceDeviceInRackBatchParams {
+  /** Placements to make in one call; each is attempted independently in array order
+   *  (best-effort), so an earlier placement can affect a later one (it consumes the U
+   *  span / half-rack side, and a device already placed by an earlier item is rejected
+   *  by a later one). */
+  placements: PlaceDeviceInRackParams[];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -20,8 +20,9 @@ export const PROTOCOL_VERSION = 1;
 
 /** The bridge tools: the eight Ship-1 "working core" tools, the two Ship-2
  *  "editing & layout" tools (move_device, delete_connection), the two Ship-3
- *  "batch" tools (add_devices, connect_devices_batch), and the two Ship-4
- *  "rooms" tools (create_room, place_device_in_room). */
+ *  "batch" tools (add_devices, connect_devices_batch), the two Ship-4
+ *  "rooms" tools (create_room, place_device_in_room), and the Ship-5
+ *  "annotations" tool (add_note). */
 export type CommandType =
   | "get_schematic"
   | "list_devices"
@@ -36,7 +37,8 @@ export type CommandType =
   | "add_devices"
   | "connect_devices_batch"
   | "create_room"
-  | "place_device_in_room";
+  | "place_device_in_room"
+  | "add_note";
 
 /** Max items accepted by a single batch tool call (input arrives over the bridge,
  *  so it is capped). The mcp-server tool schemas mirror this as `maxItems`. */
@@ -185,6 +187,15 @@ export interface PlaceDeviceInRoomParams {
    *  device's center must land inside the room or the call fails (nothing changes). */
   x?: number;
   y?: number;
+}
+
+export interface AddNoteParams {
+  /** Plain text for the note card. It is HTML-escaped on the way in (the note
+   *  renders as HTML), so it always shows literally; newlines become line breaks. */
+  text: string;
+  /** Note top-left position in canvas coordinates. */
+  x: number;
+  y: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -18,8 +18,9 @@ export const DEFAULT_BRIDGE_PORT = 8765;
  *  refuses to pair instead of misbehaving. */
 export const PROTOCOL_VERSION = 1;
 
-/** The bridge tools: the eight Ship-1 "working core" tools plus the two Ship-2
- *  "editing & layout" tools (move_device, delete_connection). */
+/** The bridge tools: the eight Ship-1 "working core" tools, the two Ship-2
+ *  "editing & layout" tools (move_device, delete_connection), and the two Ship-3
+ *  "batch" tools (add_devices, connect_devices_batch). */
 export type CommandType =
   | "get_schematic"
   | "list_devices"
@@ -30,7 +31,13 @@ export type CommandType =
   | "connect_devices"
   | "delete_device"
   | "move_device"
-  | "delete_connection";
+  | "delete_connection"
+  | "add_devices"
+  | "connect_devices_batch";
+
+/** Max items accepted by a single batch tool call (input arrives over the bridge,
+ *  so it is capped). The mcp-server tool schemas mirror this as `maxItems`. */
+export const MAX_BATCH_ITEMS = 100;
 
 /** Which two-sided face of a port to wire. Required only for bidirectional ports
  *  (`in`/`out`) and passthrough ports (`rear`/`front`); ignored for plain ports. */
@@ -141,6 +148,17 @@ export interface MoveDeviceParams {
 export interface DeleteConnectionParams {
   /** The connection (edge) id from get_schematic / connect_devices. */
   connectionId: string;
+}
+
+export interface AddDevicesParams {
+  /** Devices to add in one call; each is added independently (best-effort). */
+  devices: AddDeviceParams[];
+}
+
+export interface ConnectDevicesBatchParams {
+  /** Connections to make in one call; each is attempted independently in array
+   *  order (best-effort), so an earlier connection can affect a later one. */
+  connections: ConnectDevicesParams[];
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -124,6 +124,26 @@ export function validateRoomSize(width: unknown, height: unknown): RoomSizeResul
   return { ok: true, size: { width: w, height: h } };
 }
 
+/**
+ * Convert untrusted plain text into safe note HTML. Note nodes store HTML and are
+ * rendered via innerHTML (then re-sanitized by sanitizeNoteHtml on display/import),
+ * so raw bridge text must be entity-escaped — otherwise `<`/`&` would corrupt the
+ * markup or open an XSS hole. The output contains only escaped text plus `<br>`, so
+ * it shows the text literally and is a no-op under sanitizeNoteHtml.
+ *
+ * CRLF / lone CR are normalized to LF first so every newline style becomes a single
+ * `<br>`. (HTML still collapses runs of spaces — that is inherent to HTML rendering,
+ * not something escaping can preserve.)
+ */
+export function noteTextToHtml(text: string): string {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\n/g, "<br>");
+}
+
 /** Minimal shape of an edge this planner needs — kept structural so validation.ts
  *  stays dependency-free (no import from the rest of src/). */
 interface RemovableEdge {

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -3,7 +3,7 @@
  * unit-testable in isolation. The bridge (`src/mcpBridge.ts`) wraps these and
  * applies their results through the store actions.
  */
-import { SAFE_DEVICE_FIELDS, type PortFace } from "./protocol";
+import { SAFE_DEVICE_FIELDS, RACK_TYPES, type PortFace } from "./protocol";
 
 export interface ClassifiedProperties {
   /** New device label, if `label` was supplied (apply via updateDeviceLabel). */
@@ -260,4 +260,75 @@ export function runBatch<I, T>(
     }
   });
   return { ok: true, results, succeeded, failed };
+}
+
+// ── Rack helpers (Ship 7) ──────────────────────────────────────────
+// Pure validators for the rack tools. The store-state-dependent checks (slot
+// availability, which page holds a rack) stay in the bridge handler; these cover only
+// the untrusted scalar inputs that arrive over the bridge.
+
+export type UPositionResult =
+  | { ok: true; u: number }
+  | { ok: false; error: string };
+
+/** Validate a rack U position. Must be a whole number >= 1 (1-based, bottom-up). The
+ *  upper bound is rack-specific and is enforced by the store's isRackSlotAvailable, not
+ *  here. */
+export function validateUPosition(u: unknown): UPositionResult {
+  if (typeof u !== "number" || !Number.isInteger(u) || u < 1) {
+    return { ok: false, error: "uPosition must be a whole number of 1 or more (1-based, from the bottom)." };
+  }
+  return { ok: true, u };
+}
+
+export type RackFaceResult =
+  | { ok: true; face: "front" | "rear" }
+  | { ok: false; error: string };
+
+/** Validate the optional rack face. Omitted -> "front". Only "front"/"rear" are valid
+ *  (the 2-post-rear restriction is rack-specific and checked in the handler). */
+export function validateRackFace(face: unknown): RackFaceResult {
+  if (face === undefined) return { ok: true, face: "front" };
+  if (face === "front" || face === "rear") return { ok: true, face };
+  return { ok: false, error: `face must be "front" or "rear".` };
+}
+
+/** Editor clamps for a rack, mirroring RackSidebar.tsx so the bridge can't create a rack
+ *  outside the range a user could build by hand. */
+export const RACK_MIN_HEIGHT_U = 2;
+export const RACK_MAX_HEIGHT_U = 60;
+export const RACK_MIN_DEPTH_MM = 100;
+export const RACK_MAX_DEPTH_MM = 2000;
+export const DEFAULT_RACK_HEIGHT_U = 42;
+export const DEFAULT_RACK_DEPTH_MM = 600;
+
+export type RackSpecResult =
+  | { ok: true; rackType: (typeof RACK_TYPES)[number]; heightU: number; depthMm: number }
+  | { ok: false; error: string };
+
+/** Validate + normalize a create_rack spec. rackType defaults to "floor-19" and must be
+ *  one of RACK_TYPES. heightU/depthMm default to 42U / 600mm and are rounded then clamped
+ *  to the editor's ranges; a non-numeric (but supplied) value is rejected rather than
+ *  silently defaulted. */
+export function validateRackSpec(
+  rackType: unknown,
+  heightU: unknown,
+  depthMm: unknown,
+): RackSpecResult {
+  const rt = rackType === undefined ? "floor-19" : rackType;
+  if (typeof rt !== "string" || !(RACK_TYPES as readonly string[]).includes(rt)) {
+    return { ok: false, error: `rackType must be one of: ${RACK_TYPES.join(", ")}.` };
+  }
+  const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, Math.round(v)));
+  let h = DEFAULT_RACK_HEIGHT_U;
+  if (heightU !== undefined) {
+    if (!Number.isFinite(heightU)) return { ok: false, error: "heightU must be a finite number." };
+    h = clamp(heightU as number, RACK_MIN_HEIGHT_U, RACK_MAX_HEIGHT_U);
+  }
+  let d = DEFAULT_RACK_DEPTH_MM;
+  if (depthMm !== undefined) {
+    if (!Number.isFinite(depthMm)) return { ok: false, error: "depthMm must be a finite number." };
+    d = clamp(depthMm as number, RACK_MIN_DEPTH_MM, RACK_MAX_DEPTH_MM);
+  }
+  return { ok: true, rackType: rt as (typeof RACK_TYPES)[number], heightU: h, depthMm: d };
 }

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -144,6 +144,37 @@ export function noteTextToHtml(text: string): string {
     .replace(/\n/g, "<br>");
 }
 
+export type CardForSlotResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/**
+ * Decide whether a card template may be installed into a modular slot. A card "fits"
+ * a slot only when their slot families match exactly. The store's swapCard does NOT
+ * check this (it installs any resolvable card blindly), so the bridge enforces it —
+ * otherwise an AI could install, say, an audio card into a video slot. Both families
+ * come from the live data: the slot's denormalized `slotFamily` (set on nested slots
+ * too) and the card template's `slotFamily` (present only on expansion-card templates).
+ */
+export function validateCardForSlot(
+  slotFamily: string | undefined,
+  cardSlotFamily: string | undefined,
+): CardForSlotResult {
+  if (!cardSlotFamily) {
+    return { ok: false, error: "That template is not an expansion card (it has no slot family)." };
+  }
+  if (!slotFamily) {
+    return { ok: false, error: "That slot has no slot family, so no card can be matched to it." };
+  }
+  if (slotFamily !== cardSlotFamily) {
+    return {
+      ok: false,
+      error: `Card slot family "${cardSlotFamily}" does not fit slot family "${slotFamily}".`,
+    };
+  }
+  return { ok: true };
+}
+
 /** Minimal shape of an edge this planner needs — kept structural so validation.ts
  *  stays dependency-free (no import from the rest of src/). */
 interface RemovableEdge {

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -80,3 +80,56 @@ export function resolveHandleFromCandidates(
   }
   return { ok: false, error: `Invalid face "${face}" for port "${portId}". Valid: ${faces.join(", ")}.` };
 }
+
+export type PositionResult =
+  | { ok: true; position: { x: number; y: number } }
+  | { ok: false; error: string };
+
+/** Validate the x/y of a move command. Input is untrusted (it arrives over the
+ *  bridge), so only finite numbers are accepted — NaN, Infinity and non-numbers
+ *  are rejected rather than written into a node's position. */
+export function validatePosition(x: unknown, y: unknown): PositionResult {
+  if (!Number.isFinite(x) || !Number.isFinite(y)) {
+    return { ok: false, error: "x and y must both be finite numbers." };
+  }
+  return { ok: true, position: { x: x as number, y: y as number } };
+}
+
+/** Minimal shape of an edge this planner needs — kept structural so validation.ts
+ *  stays dependency-free (no import from the rest of src/). */
+interface RemovableEdge {
+  id: string;
+  data?: { linkedConnectionId?: string } | null;
+}
+
+export type ConnectionRemovalPlan =
+  | { ok: true; removeId: string }
+  | { ok: false; error: string };
+
+/**
+ * Decide whether a single connection can be removed by id.
+ *   - id not found            -> error
+ *   - stubbed/linked edge      -> rejected (it has a partner leg + stub-label node
+ *     that a plain edge-remove would orphan; cascading that is out of scope for
+ *     this Beta slice, so we fail honestly instead of corrupting the drawing)
+ *   - plain edge               -> ok, remove just that edge
+ */
+export function planConnectionRemoval(
+  edges: RemovableEdge[],
+  connectionId: string,
+): ConnectionRemovalPlan {
+  const edge = edges.find((e) => e.id === connectionId);
+  if (!edge) {
+    return { ok: false, error: `No connection found with id "${connectionId}".` };
+  }
+  if (edge.data?.linkedConnectionId) {
+    return {
+      ok: false,
+      error:
+        `Connection "${connectionId}" is a stubbed (linked) connection; removing it ` +
+        `via the AI bridge isn't supported yet — remove it in the editor, or delete ` +
+        `one of its devices.`,
+    };
+  }
+  return { ok: true, removeId: connectionId };
+}

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -133,3 +133,51 @@ export function planConnectionRemoval(
   }
   return { ok: true, removeId: connectionId };
 }
+
+export interface BatchItemResult<T> {
+  index: number;
+  ok: boolean;
+  result?: T;
+  error?: string;
+}
+
+export type BatchOutcome<T> =
+  | { ok: false; error: string }
+  | { ok: true; results: BatchItemResult<T>[]; succeeded: number; failed: number };
+
+/**
+ * Run a best-effort batch: validate that `items` is a non-empty array within `max`,
+ * then apply `fn` to each item in order, capturing per-item success/failure instead
+ * of aborting the whole batch. `fn` is injected (the store-touching work lives in the
+ * caller), so this stays pure and unit-testable. The caller turns an `ok:false`
+ * outcome into a thrown error — it must not be returned as a successful tool result.
+ */
+export function runBatch<I, T>(
+  items: unknown,
+  max: number,
+  fn: (item: I, index: number) => T,
+): BatchOutcome<T> {
+  if (!Array.isArray(items)) {
+    return { ok: false, error: "Expected an array of items." };
+  }
+  if (items.length === 0) {
+    return { ok: false, error: "The batch is empty — provide at least one item." };
+  }
+  if (items.length > max) {
+    return { ok: false, error: `Too many items (${items.length}); the maximum is ${max} per call.` };
+  }
+  const results: BatchItemResult<T>[] = [];
+  let succeeded = 0;
+  let failed = 0;
+  items.forEach((item, index) => {
+    try {
+      const result = fn(item as I, index);
+      results.push({ index, ok: true, result });
+      succeeded++;
+    } catch (err) {
+      results.push({ index, ok: false, error: err instanceof Error ? err.message : String(err) });
+      failed++;
+    }
+  });
+  return { ok: true, results, succeeded, failed };
+}

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -144,6 +144,32 @@ export function noteTextToHtml(text: string): string {
     .replace(/\n/g, "<br>");
 }
 
+/**
+ * Best-effort inverse of noteTextToHtml: render a note's stored HTML back to readable
+ * plain text for the MCP read surface (get_schematic). The block-level tags the note
+ * sanitizer keeps (`br`/`div`/`p`/`li`/`ul`/`ol`) become line breaks, so block structure
+ * isn't collapsed (`<div>A</div><div>B</div>` -> "A\nB", never "AB"); the remaining
+ * inline formatting tags (b/i/strong/…) are dropped; HTML entities are unescaped (&amp;
+ * last, so `&amp;lt;` -> `&lt;`). Lossy for rich formatting — which is fine for a read
+ * surface, and update_note replaces a note's content with plain text anyway.
+ */
+export function noteHtmlToText(html: string): string {
+  if (!html) return "";
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/?(?:div|p|li|ul|ol|h[1-6])\b[^>]*>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&amp;/gi, "&")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{2,}/g, "\n")
+    .trim();
+}
+
 export type CardForSlotResult =
   | { ok: true }
   | { ok: false; error: string };

--- a/src/mcp/validation.ts
+++ b/src/mcp/validation.ts
@@ -95,6 +95,35 @@ export function validatePosition(x: unknown, y: unknown): PositionResult {
   return { ok: true, position: { x: x as number, y: y as number } };
 }
 
+/** Minimum room dimensions, matching the editor's room NodeResizer (RoomNode.tsx),
+ *  so the bridge can't create a room smaller than one a user could draw by hand. */
+export const MIN_ROOM_WIDTH = 200;
+export const MIN_ROOM_HEIGHT = 150;
+
+export type RoomSizeResult =
+  | { ok: true; size: { width: number; height: number } | undefined }
+  | { ok: false; error: string };
+
+/** Validate the optional width/height of a create_room command. Input is untrusted
+ *  (it arrives over the bridge). Both omitted -> ok with size undefined (the caller
+ *  uses the 400x300 default). If either is given, BOTH must be finite numbers at or
+ *  above the editor minimums; partial or sub-minimum sizes are rejected rather than
+ *  written into a room that couldn't be created in the editor. */
+export function validateRoomSize(width: unknown, height: unknown): RoomSizeResult {
+  if (width === undefined && height === undefined) {
+    return { ok: true, size: undefined };
+  }
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return { ok: false, error: "width and height must both be finite numbers, or both omitted." };
+  }
+  const w = width as number;
+  const h = height as number;
+  if (w < MIN_ROOM_WIDTH || h < MIN_ROOM_HEIGHT) {
+    return { ok: false, error: `Room is too small; the minimum size is ${MIN_ROOM_WIDTH}x${MIN_ROOM_HEIGHT}.` };
+  }
+  return { ok: true, size: { width: w, height: h } };
+}
+
 /** Minimal shape of an edge this planner needs — kept structural so validation.ts
  *  stays dependency-free (no import from the rest of src/). */
 interface RemovableEdge {

--- a/src/mcpBridge.ts
+++ b/src/mcpBridge.ts
@@ -35,6 +35,7 @@ import {
   type DeleteConnectionParams,
   type CreateRoomParams,
   type PlaceDeviceInRoomParams,
+  type AddNoteParams,
   type PortFace,
 } from "./mcp/protocol";
 import {
@@ -44,6 +45,7 @@ import {
   validateRoomSize,
   planConnectionRemoval,
   runBatch,
+  noteTextToHtml,
 } from "./mcp/validation";
 import type { DeviceData, DeviceTemplate, Port, SchematicNode } from "./types";
 
@@ -171,7 +173,7 @@ function connectDevicesCore(p: ConnectDevicesParams) {
 // ---------------------------------------------------------------------------
 // Command handlers — each returns a JSON-serializable result or throws CommandError.
 // ---------------------------------------------------------------------------
-const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown | Promise<unknown>> = {
+export const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown | Promise<unknown>> = {
   get_schematic: () => {
     const devices = deviceNodes().map((n) => {
       const d = n.data as DeviceData;
@@ -378,6 +380,24 @@ const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown
       );
     }
     return { nodeId: deviceId, roomId, position: rel };
+  },
+
+  add_note: (params) => {
+    const { text, x, y } = params as unknown as AddNoteParams;
+    if (typeof text !== "string" || text.trim() === "") {
+      throw new CommandError("text is required (a non-empty note).");
+    }
+    const pos = validatePosition(x, y);
+    if (!pos.ok) throw new CommandError(pos.error);
+    // No store action returns the new note's id, and addNote/updateNoteHtml are two
+    // calls — but only addNote pushes undo, so the pair is a single undo step. Snapshot
+    // ids, create the (empty) note, then set its escaped HTML on the new node.
+    const before = new Set(st().nodes.map((n) => n.id));
+    st().addNote(pos.position);
+    const note = st().nodes.find((n) => n.type === "note" && !before.has(n.id));
+    if (!note) throw new CommandError("Note was not created (no new note node appeared).");
+    st().updateNoteHtml(note.id, noteTextToHtml(text));
+    return { noteId: note.id, text, position: pos.position };
   },
 };
 

--- a/src/mcpBridge.ts
+++ b/src/mcpBridge.ts
@@ -16,7 +16,7 @@ import { useEffect } from "react";
 import type { Connection } from "@xyflow/react";
 import { useSchematicStore } from "./store";
 import { getPortAbsolutePositions } from "./snapUtils";
-import { getBundledTemplates, getTemplateById, fetchTemplates } from "./templateApi";
+import { getBundledTemplates, getTemplateById, getCardsByFamily, fetchTemplates } from "./templateApi";
 import {
   DEFAULT_BRIDGE_PORT,
   PROTOCOL_VERSION,
@@ -36,6 +36,9 @@ import {
   type CreateRoomParams,
   type PlaceDeviceInRoomParams,
   type AddNoteParams,
+  type ListSlotCardsParams,
+  type InstallCardParams,
+  type RemoveCardParams,
   type PortFace,
 } from "./mcp/protocol";
 import {
@@ -46,8 +49,9 @@ import {
   planConnectionRemoval,
   runBatch,
   noteTextToHtml,
+  validateCardForSlot,
 } from "./mcp/validation";
-import type { DeviceData, DeviceTemplate, Port, SchematicNode } from "./types";
+import type { DeviceData, DeviceTemplate, InstalledSlot, Port, SchematicNode } from "./types";
 
 export type BridgeStatus = "off" | "connecting" | "connected" | "error";
 
@@ -75,6 +79,31 @@ function requireDevice(nodeId: string): SchematicNode {
 
 function portSummary(p: Port) {
   return { id: p.id, label: p.label, direction: p.direction, signalType: p.signalType };
+}
+
+/** Compact view of a device's modular slot, for get_device. `filled` is the quick
+ *  flag; cardTemplateId/cardLabel describe the installed card (absent when empty). */
+function slotSummary(s: InstalledSlot) {
+  return {
+    slotId: s.slotId,
+    label: s.label,
+    slotFamily: s.slotFamily,
+    parentSlotId: s.parentSlotId,
+    filled: Boolean(s.cardTemplateId),
+    cardTemplateId: s.cardTemplateId,
+    cardLabel: s.cardLabel,
+  };
+}
+
+/** Find an installed slot on a device, or throw a readable CommandError. Used by the
+ *  slot tools so they fully pre-validate before touching the structural swapCard
+ *  action (which pushes an undo entry before its own guards). */
+function requireSlot(device: SchematicNode, slotId: string): InstalledSlot {
+  const slot = ((device.data as DeviceData).slots ?? []).find((s) => s.slotId === slotId);
+  if (!slot) {
+    throw new CommandError(`No slot found with id "${slotId}" on device "${device.id}".`);
+  }
+  return slot;
 }
 
 /** The full discoverable set: the live community library (which already has the
@@ -184,6 +213,7 @@ export const handlers: Record<CommandType, (params: Record<string, unknown>) => 
         manufacturer: d.manufacturer,
         position: n.position,
         parentId: n.parentId,
+        slotCount: (d.slots ?? []).length,
         ports: (d.ports ?? []).map(portSummary),
       };
     });
@@ -231,6 +261,7 @@ export const handlers: Record<CommandType, (params: Record<string, unknown>) => 
       position: node.position,
       parentId: node.parentId,
       ports: (d.ports ?? []).map(portSummary),
+      slots: (d.slots ?? []).map(slotSummary),
     };
   },
 
@@ -398,6 +429,90 @@ export const handlers: Record<CommandType, (params: Record<string, unknown>) => 
     if (!note) throw new CommandError("Note was not created (no new note node appeared).");
     st().updateNoteHtml(note.id, noteTextToHtml(text));
     return { noteId: note.id, text, position: pos.position };
+  },
+
+  list_slot_cards: (params) => {
+    const { deviceId, slotId } = params as unknown as ListSlotCardsParams;
+    const device = requireDevice(deviceId);
+    const slot = requireSlot(device, slotId);
+    if (!slot.slotFamily) return { slotId, slotFamily: undefined, cards: [] };
+    // Reads the current library view (live-library cache if warmed by an earlier
+    // search_templates call, plus the bundled floor) and this schematic's custom
+    // templates — the same view install_card resolves against. Only cards with a real
+    // template id are returned: install_card resolves by id, so an id-less card could
+    // be listed but not installed (kept consistent here).
+    // Known minor limitation: if a custom template reuses a library card's id,
+    // install_card's getTemplateById prefers the library copy, so the listed-vs-
+    // installed card could differ. This can't corrupt state — install_card re-checks
+    // the slot family and re-reads the slot, so a wrong-family resolution just rejects.
+    const cards = getCardsByFamily(slot.slotFamily, st().customTemplates)
+      .filter((t) => Boolean(t.id))
+      .map((t) => ({
+        templateId: t.id!,
+        label: t.label,
+        manufacturer: t.manufacturer,
+        modelNumber: t.modelNumber,
+      }));
+    return { slotId, slotFamily: slot.slotFamily, cards };
+  },
+
+  install_card: (params) => {
+    const { deviceId, slotId, cardTemplateId } = params as unknown as InstallCardParams;
+    const device = requireDevice(deviceId);
+    const slot = requireSlot(device, slotId);
+    // Refuse to overwrite a filled slot: swapCard would replace the card and drop its
+    // ports + connected connections. Make the AI remove_card first so that loss is
+    // explicit, never silent.
+    if (slot.cardTemplateId) {
+      throw new CommandError(
+        `Slot "${slotId}" already holds a card ("${slot.cardLabel ?? slot.cardTemplateId}"). ` +
+          `Remove it first with remove_card, then install.`,
+      );
+    }
+    if (!cardTemplateId) throw new CommandError("cardTemplateId is required.");
+    // Resolve exactly the way swapCard will (getTemplateById over the current library
+    // view + custom templates), so a card we accept is one swapCard can actually find.
+    const card = getTemplateById(cardTemplateId, st().customTemplates);
+    if (!card) {
+      throw new CommandError(
+        `No card template found for "${cardTemplateId}". Call list_slot_cards (or ` +
+          `search_templates to load the full library) first.`,
+      );
+    }
+    const compat = validateCardForSlot(slot.slotFamily, card.slotFamily);
+    if (!compat.ok) throw new CommandError(compat.error);
+    if (!card.id) throw new CommandError(`Card template "${cardTemplateId}" has no id and cannot be installed.`);
+    st().swapCard(deviceId, slotId, card.id);
+    // Confirm by re-reading the slot (swapCard returns void); guards against any
+    // residual resolution mismatch rather than reporting a blind success.
+    const after = requireSlot(requireDevice(deviceId), slotId);
+    if (after.cardTemplateId !== card.id) {
+      throw new CommandError(`Card "${card.id}" could not be installed into slot "${slotId}".`);
+    }
+    return {
+      deviceId,
+      slotId,
+      cardTemplateId: card.id,
+      cardLabel: after.cardLabel,
+      portIds: after.portIds,
+    };
+  },
+
+  remove_card: (params) => {
+    const { deviceId, slotId } = params as unknown as RemoveCardParams;
+    const device = requireDevice(deviceId);
+    const slot = requireSlot(device, slotId);
+    // Empty slot -> nothing to remove. Reject WITHOUT calling swapCard, which would
+    // push an empty undo step and rebuild the (already-empty) slot for no reason.
+    if (!slot.cardTemplateId) {
+      throw new CommandError(`Slot "${slotId}" is already empty.`);
+    }
+    st().swapCard(deviceId, slotId, null);
+    const after = requireSlot(requireDevice(deviceId), slotId);
+    if (after.cardTemplateId) {
+      throw new CommandError(`Card could not be removed from slot "${slotId}".`);
+    }
+    return { deviceId, slotId, emptied: true };
   },
 };
 

--- a/src/mcpBridge.ts
+++ b/src/mcpBridge.ts
@@ -45,6 +45,8 @@ import {
   type RemoveDeviceFromRackParams,
   type UpdateNoteParams,
   type DeleteNoteParams,
+  type InstallCardBatchParams,
+  type PlaceDeviceInRackBatchParams,
   type PortFace,
 } from "./mcp/protocol";
 import {
@@ -306,6 +308,147 @@ function connectDevicesCore(p: ConnectDevicesParams) {
     );
   }
   return { connected: true, edgeId: edge.id, sourceHandle, targetHandle };
+}
+
+/** Install one expansion card into an empty slot. Shared by install_card and
+ *  install_card_batch so the two behave identically. Fully pre-validates (device/slot
+ *  exist, slot empty, card resolves the way swapCard will, family matches) before the
+ *  structural swapCard, then re-reads to confirm. Throws CommandError on any failure. */
+function installCardCore(p: InstallCardParams) {
+  const { deviceId, slotId, cardTemplateId } = p;
+  const device = requireDevice(deviceId);
+  const slot = requireSlot(device, slotId);
+  // Refuse to overwrite a filled slot: swapCard would replace the card and drop its
+  // ports + connected connections. Make the AI remove_card first so that loss is
+  // explicit, never silent.
+  if (slot.cardTemplateId) {
+    throw new CommandError(
+      `Slot "${slotId}" already holds a card ("${slot.cardLabel ?? slot.cardTemplateId}"). ` +
+        `Remove it first with remove_card, then install.`,
+    );
+  }
+  if (!cardTemplateId) throw new CommandError("cardTemplateId is required.");
+  // Resolve exactly the way swapCard will (getTemplateById over the current library
+  // view + custom templates), so a card we accept is one swapCard can actually find.
+  const card = getTemplateById(cardTemplateId, st().customTemplates);
+  if (!card) {
+    throw new CommandError(
+      `No card template found for "${cardTemplateId}". Call list_slot_cards (or ` +
+        `search_templates to load the full library) first.`,
+    );
+  }
+  const compat = validateCardForSlot(slot.slotFamily, card.slotFamily);
+  if (!compat.ok) throw new CommandError(compat.error);
+  if (!card.id) throw new CommandError(`Card template "${cardTemplateId}" has no id and cannot be installed.`);
+  st().swapCard(deviceId, slotId, card.id);
+  // Confirm by re-reading the slot (swapCard returns void); guards against any
+  // residual resolution mismatch rather than reporting a blind success. NOTE: this is
+  // the one throw that fires AFTER swapCard (which pushes undo before mutating), so it is
+  // the single exception to install_card_batch's "a failed item changes nothing" contract
+  // — but it is a defensive guard against a swapCard regression, not a reachable path
+  // given the pre-validation above (slot empty, card resolves, family matches). All the
+  // ordinary install_card failures throw before swapCard, so a failed batch item normally
+  // leaves no mutation and no undo step.
+  const after = requireSlot(requireDevice(deviceId), slotId);
+  if (after.cardTemplateId !== card.id) {
+    throw new CommandError(`Card "${card.id}" could not be installed into slot "${slotId}".`);
+  }
+  return {
+    deviceId,
+    slotId,
+    cardTemplateId: card.id,
+    cardLabel: after.cardLabel,
+    portIds: after.portIds,
+  };
+}
+
+/** Mount one device into a rack at a U position. Shared by place_device_in_rack and
+ *  place_device_in_rack_batch. Pre-checks isRackSlotAvailable (the store action does NOT)
+ *  and the editor's one-rack / 2-post-rear / oversize / shelf-only rules before the
+ *  structural addPlacementSmart. Throws CommandError on any failure. */
+function placeDeviceInRackCore(p: PlaceDeviceInRackParams) {
+  const { deviceId, rackId, uPosition, face } = p;
+  const node = requireDevice(deviceId);
+  const data = node.data as DeviceData;
+  const { page, rack } = requireRack(rackId);
+  const f = validateRackFace(face);
+  if (!f.ok) throw new CommandError(f.error);
+  const u = validateUPosition(uPosition);
+  if (!u.ok) throw new CommandError(u.error);
+
+  // 2-post frames have no rear face (mirrors the editor's isRackRearBlocked).
+  if (f.face === "rear" && rack.rackType === "open-2post") {
+    throw new CommandError(`Rack "${rackId}" is a 2-post frame, which has no rear face — use face "front".`);
+  }
+
+  // A device is placed in at most one rack at a time: the editor hides "Place in Rack"
+  // once a device is placed and excludes already-placed devices from auto-fill, but the
+  // store does not enforce singularity. Reject a duplicate placement explicitly.
+  for (const rp of rackPages()) {
+    const existing = rp.placements.find((pl) => pl.deviceNodeId === deviceId);
+    if (existing) {
+      throw new CommandError(
+        `Device "${deviceId}" is already placed in a rack (placement "${existing.id}"). ` +
+          `Remove it first with remove_device_from_rack.`,
+      );
+    }
+  }
+
+  const form = inferRackForm(data);
+  if (form === "oversize") {
+    throw new CommandError(`Device "${deviceId}" is too wide to mount in a 19" rack (oversize).`);
+  }
+  if (form === "shelf-only") {
+    // Shelf-only gear (too small for a direct rack-mount panel) needs a shelf to sit on.
+    // The editor creates that shelf and lets the user position the device on it; doing
+    // that from the bridge would mean auto-creating a shelf whose later cleanup can't be
+    // told apart from a user-built shelf (no provenance flag on the data). Rather than
+    // risk dropping a user's shelf or leaving an orphan, shelf placement stays an editor
+    // task for this slice.
+    throw new CommandError(
+      `Device "${deviceId}" is too small for a direct rack-mount (it needs a shelf). ` +
+        `Add a shelf and place it on the shelf in the editor.`,
+    );
+  }
+  const heightU = inferRackHeightU(data);
+
+  // addPlacementSmart does NOT check occupancy — it appends the placement unconditionally
+  // (only its oversize/no-page/no-device early returns bail). So the bridge MUST pre-check
+  // isRackSlotAvailable here, or two devices could be stacked into the same U range.
+  let preferredHalfRackSide: "left" | "right" | undefined;
+  if (form === "half") {
+    // Pick the exact side that is free per the authoritative occupancy check, then pass
+    // it to addPlacementSmart — its internal side heuristic is weaker (ignores multi-U
+    // overlap, full-width blockers and accessories), so "either side free" alone is not
+    // safe. isRackSlotAvailable(side)=true guarantees its sideTaken(side)=false, so the
+    // side we pass is honored.
+    const leftFree = st().isRackSlotAvailable(page.id, rackId, u.u, heightU, f.face, "left");
+    const rightFree = st().isRackSlotAvailable(page.id, rackId, u.u, heightU, f.face, "right");
+    preferredHalfRackSide = leftFree ? "left" : rightFree ? "right" : undefined;
+    if (!preferredHalfRackSide) {
+      throw new CommandError(`No free half-rack space at U${u.u} on the ${f.face} of rack "${rackId}".`);
+    }
+  } else {
+    // full / unknown — full-width direct placement spanning heightU.
+    if (!st().isRackSlotAvailable(page.id, rackId, u.u, heightU, f.face)) {
+      throw new CommandError(`U${u.u}–${u.u + heightU - 1} on the ${f.face} of rack "${rackId}" is occupied or out of bounds.`);
+    }
+  }
+
+  const res = st().addPlacementSmart(page.id, rackId, deviceId, u.u, f.face, preferredHalfRackSide);
+  if (!res.ok) {
+    throw new CommandError(`Could not place device "${deviceId}" in rack "${rackId}" (${res.reason}).`);
+  }
+  return {
+    placementId: res.placementId,
+    rackId,
+    deviceId,
+    uPosition: u.u,
+    face: f.face,
+    form,
+    heightU,
+    halfRackSide: preferredHalfRackSide,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -571,46 +714,13 @@ export const handlers: Record<CommandType, (params: Record<string, unknown>) => 
     return { slotId, slotFamily: slot.slotFamily, cards };
   },
 
-  install_card: (params) => {
-    const { deviceId, slotId, cardTemplateId } = params as unknown as InstallCardParams;
-    const device = requireDevice(deviceId);
-    const slot = requireSlot(device, slotId);
-    // Refuse to overwrite a filled slot: swapCard would replace the card and drop its
-    // ports + connected connections. Make the AI remove_card first so that loss is
-    // explicit, never silent.
-    if (slot.cardTemplateId) {
-      throw new CommandError(
-        `Slot "${slotId}" already holds a card ("${slot.cardLabel ?? slot.cardTemplateId}"). ` +
-          `Remove it first with remove_card, then install.`,
-      );
-    }
-    if (!cardTemplateId) throw new CommandError("cardTemplateId is required.");
-    // Resolve exactly the way swapCard will (getTemplateById over the current library
-    // view + custom templates), so a card we accept is one swapCard can actually find.
-    const card = getTemplateById(cardTemplateId, st().customTemplates);
-    if (!card) {
-      throw new CommandError(
-        `No card template found for "${cardTemplateId}". Call list_slot_cards (or ` +
-          `search_templates to load the full library) first.`,
-      );
-    }
-    const compat = validateCardForSlot(slot.slotFamily, card.slotFamily);
-    if (!compat.ok) throw new CommandError(compat.error);
-    if (!card.id) throw new CommandError(`Card template "${cardTemplateId}" has no id and cannot be installed.`);
-    st().swapCard(deviceId, slotId, card.id);
-    // Confirm by re-reading the slot (swapCard returns void); guards against any
-    // residual resolution mismatch rather than reporting a blind success.
-    const after = requireSlot(requireDevice(deviceId), slotId);
-    if (after.cardTemplateId !== card.id) {
-      throw new CommandError(`Card "${card.id}" could not be installed into slot "${slotId}".`);
-    }
-    return {
-      deviceId,
-      slotId,
-      cardTemplateId: card.id,
-      cardLabel: after.cardLabel,
-      portIds: after.portIds,
-    };
+  install_card: (params) => installCardCore((params ?? {}) as unknown as InstallCardParams),
+
+  install_card_batch: (params) => {
+    const { installs } = (params ?? {}) as unknown as InstallCardBatchParams;
+    const outcome = runBatch(installs, MAX_BATCH_ITEMS, (p: InstallCardParams) => installCardCore(p));
+    if (!outcome.ok) throw new CommandError(outcome.error);
+    return { results: outcome.results, succeeded: outcome.succeeded, failed: outcome.failed };
   },
 
   remove_card: (params) => {
@@ -707,89 +817,13 @@ export const handlers: Record<CommandType, (params: Record<string, unknown>) => 
     };
   },
 
-  place_device_in_rack: (params) => {
-    const { deviceId, rackId, uPosition, face } = params as unknown as PlaceDeviceInRackParams;
-    const node = requireDevice(deviceId);
-    const data = node.data as DeviceData;
-    const { page, rack } = requireRack(rackId);
-    const f = validateRackFace(face);
-    if (!f.ok) throw new CommandError(f.error);
-    const u = validateUPosition(uPosition);
-    if (!u.ok) throw new CommandError(u.error);
+  place_device_in_rack: (params) => placeDeviceInRackCore((params ?? {}) as unknown as PlaceDeviceInRackParams),
 
-    // 2-post frames have no rear face (mirrors the editor's isRackRearBlocked).
-    if (f.face === "rear" && rack.rackType === "open-2post") {
-      throw new CommandError(`Rack "${rackId}" is a 2-post frame, which has no rear face — use face "front".`);
-    }
-
-    // A device is placed in at most one rack at a time: the editor hides "Place in Rack"
-    // once a device is placed and excludes already-placed devices from auto-fill, but the
-    // store does not enforce singularity. Reject a duplicate placement explicitly.
-    for (const p of rackPages()) {
-      const existing = p.placements.find((pl) => pl.deviceNodeId === deviceId);
-      if (existing) {
-        throw new CommandError(
-          `Device "${deviceId}" is already placed in a rack (placement "${existing.id}"). ` +
-            `Remove it first with remove_device_from_rack.`,
-        );
-      }
-    }
-
-    const form = inferRackForm(data);
-    if (form === "oversize") {
-      throw new CommandError(`Device "${deviceId}" is too wide to mount in a 19" rack (oversize).`);
-    }
-    if (form === "shelf-only") {
-      // Shelf-only gear (too small for a direct rack-mount panel) needs a shelf to sit on.
-      // The editor creates that shelf and lets the user position the device on it; doing
-      // that from the bridge would mean auto-creating a shelf whose later cleanup can't be
-      // told apart from a user-built shelf (no provenance flag on the data). Rather than
-      // risk dropping a user's shelf or leaving an orphan, shelf placement stays an editor
-      // task for this slice.
-      throw new CommandError(
-        `Device "${deviceId}" is too small for a direct rack-mount (it needs a shelf). ` +
-          `Add a shelf and place it on the shelf in the editor.`,
-      );
-    }
-    const heightU = inferRackHeightU(data);
-
-    // addPlacementSmart does NOT check occupancy — it appends the placement unconditionally
-    // (only its oversize/no-page/no-device early returns bail). So the bridge MUST pre-check
-    // isRackSlotAvailable here, or two devices could be stacked into the same U range.
-    let preferredHalfRackSide: "left" | "right" | undefined;
-    if (form === "half") {
-      // Pick the exact side that is free per the authoritative occupancy check, then pass
-      // it to addPlacementSmart — its internal side heuristic is weaker (ignores multi-U
-      // overlap, full-width blockers and accessories), so "either side free" alone is not
-      // safe. isRackSlotAvailable(side)=true guarantees its sideTaken(side)=false, so the
-      // side we pass is honored.
-      const leftFree = st().isRackSlotAvailable(page.id, rackId, u.u, heightU, f.face, "left");
-      const rightFree = st().isRackSlotAvailable(page.id, rackId, u.u, heightU, f.face, "right");
-      preferredHalfRackSide = leftFree ? "left" : rightFree ? "right" : undefined;
-      if (!preferredHalfRackSide) {
-        throw new CommandError(`No free half-rack space at U${u.u} on the ${f.face} of rack "${rackId}".`);
-      }
-    } else {
-      // full / unknown — full-width direct placement spanning heightU.
-      if (!st().isRackSlotAvailable(page.id, rackId, u.u, heightU, f.face)) {
-        throw new CommandError(`U${u.u}–${u.u + heightU - 1} on the ${f.face} of rack "${rackId}" is occupied or out of bounds.`);
-      }
-    }
-
-    const res = st().addPlacementSmart(page.id, rackId, deviceId, u.u, f.face, preferredHalfRackSide);
-    if (!res.ok) {
-      throw new CommandError(`Could not place device "${deviceId}" in rack "${rackId}" (${res.reason}).`);
-    }
-    return {
-      placementId: res.placementId,
-      rackId,
-      deviceId,
-      uPosition: u.u,
-      face: f.face,
-      form,
-      heightU,
-      halfRackSide: preferredHalfRackSide,
-    };
+  place_device_in_rack_batch: (params) => {
+    const { placements } = (params ?? {}) as unknown as PlaceDeviceInRackBatchParams;
+    const outcome = runBatch(placements, MAX_BATCH_ITEMS, (p: PlaceDeviceInRackParams) => placeDeviceInRackCore(p));
+    if (!outcome.ok) throw new CommandError(outcome.error);
+    return { results: outcome.results, succeeded: outcome.succeeded, failed: outcome.failed };
   },
 
   remove_device_from_rack: (params) => {

--- a/src/mcpBridge.ts
+++ b/src/mcpBridge.ts
@@ -28,9 +28,16 @@ import {
   type GetDeviceParams,
   type SearchTemplatesParams,
   type DeleteDeviceParams,
+  type MoveDeviceParams,
+  type DeleteConnectionParams,
   type PortFace,
 } from "./mcp/protocol";
-import { classifyDeviceProperties, resolveHandleFromCandidates } from "./mcp/validation";
+import {
+  classifyDeviceProperties,
+  resolveHandleFromCandidates,
+  validatePosition,
+  planConnectionRemoval,
+} from "./mcp/validation";
 import type { DeviceData, DeviceTemplate, Port, SchematicNode } from "./types";
 
 export type BridgeStatus = "off" | "connecting" | "connected" | "error";
@@ -112,6 +119,7 @@ const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown
         deviceType: d.deviceType,
         manufacturer: d.manufacturer,
         position: n.position,
+        parentId: n.parentId,
         ports: (d.ports ?? []).map(portSummary),
       };
     });
@@ -141,6 +149,7 @@ const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown
         manufacturer: d.manufacturer,
         modelNumber: d.modelNumber,
         position: n.position,
+        parentId: n.parentId,
       };
     }),
 
@@ -156,6 +165,7 @@ const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown
       manufacturer: d.manufacturer,
       modelNumber: d.modelNumber,
       position: node.position,
+      parentId: node.parentId,
       ports: (d.ports ?? []).map(portSummary),
     };
   },
@@ -252,6 +262,24 @@ const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown
     requireDevice(nodeId);
     st().deleteNode(nodeId);
     return { deleted: true, nodeId };
+  },
+
+  move_device: (params) => {
+    const { nodeId, x, y } = params as unknown as MoveDeviceParams;
+    requireDevice(nodeId);
+    const pos = validatePosition(x, y);
+    if (!pos.ok) throw new CommandError(pos.error);
+    st().moveDevice(nodeId, pos.position);
+    return { nodeId, position: pos.position };
+  },
+
+  delete_connection: (params) => {
+    const { connectionId } = params as unknown as DeleteConnectionParams;
+    if (!connectionId) throw new CommandError("connectionId is required.");
+    const plan = planConnectionRemoval(st().edges, connectionId);
+    if (!plan.ok) throw new CommandError(plan.error);
+    st().deleteConnection(plan.removeId);
+    return { deleted: true, connectionId };
   },
 };
 

--- a/src/mcpBridge.ts
+++ b/src/mcpBridge.ts
@@ -20,11 +20,14 @@ import { getBundledTemplates, getTemplateById, fetchTemplates } from "./template
 import {
   DEFAULT_BRIDGE_PORT,
   PROTOCOL_VERSION,
+  MAX_BATCH_ITEMS,
   type CommandType,
   type BridgeServerMessage,
   type AddDeviceParams,
+  type AddDevicesParams,
   type SetDevicePropertyParams,
   type ConnectDevicesParams,
+  type ConnectDevicesBatchParams,
   type GetDeviceParams,
   type SearchTemplatesParams,
   type DeleteDeviceParams,
@@ -37,6 +40,7 @@ import {
   resolveHandleFromCandidates,
   validatePosition,
   planConnectionRemoval,
+  runBatch,
 } from "./mcp/validation";
 import type { DeviceData, DeviceTemplate, Port, SchematicNode } from "./types";
 
@@ -104,6 +108,61 @@ function resolveHandle(node: SchematicNode, portId: string, face: PortFace | und
   const res = resolveHandleFromCandidates(candidates, portId, face);
   if (!res.ok) throw new CommandError(res.error);
   return res.handleId;
+}
+
+// ---------------------------------------------------------------------------
+// Shared cores — one device / one connection. Used by both the singular tools and
+// the batch tools (add_devices / connect_devices_batch), so the two stay identical.
+// Each throws CommandError on failure.
+// ---------------------------------------------------------------------------
+function addDeviceCore(spec: AddDeviceParams, templates: DeviceTemplate[]) {
+  const { templateId, label, x, y } = spec;
+  if (!templateId) throw new CommandError("templateId is required.");
+  const tpl = resolveTemplate(templateId, templates);
+  if (!tpl) throw new CommandError(`No template found for "${templateId}". Use search_templates first.`);
+  const position = { x: x ?? 0, y: y ?? 0 };
+  const before = new Set(st().nodes.map((n) => n.id));
+  st().addDevice(tpl, position);
+  const added = st().nodes.find((n) => !before.has(n.id));
+  if (!added) throw new CommandError("Device was not added (no new node appeared).");
+  const renamed = Boolean(label && label !== tpl.label);
+  if (renamed) st().updateDeviceLabel(added.id, label!);
+  // Report the final label — `added` was captured before the rename, so read the
+  // applied custom label rather than the stale template label.
+  return { nodeId: added.id, label: renamed ? label! : (added.data as DeviceData).label, position };
+}
+
+function connectDevicesCore(p: ConnectDevicesParams) {
+  const sourceNode = requireDevice(p.sourceNodeId);
+  const targetNode = requireDevice(p.targetNodeId);
+  const sourceHandle = resolveHandle(sourceNode, p.sourcePortId, p.sourceFace);
+  const targetHandle = resolveHandle(targetNode, p.targetPortId, p.targetFace);
+  const connection: Connection = {
+    source: p.sourceNodeId,
+    sourceHandle,
+    target: p.targetNodeId,
+    targetHandle,
+  };
+  if (!st().isValidConnection(connection)) {
+    throw new CommandError(
+      `That connection is not valid (incompatible direction/signal, duplicate, or self-connection).`,
+    );
+  }
+  const before = new Set(st().edges.map((e) => e.id));
+  st().onConnect(connection);
+  const edge = st().edges.find((e) => !before.has(e.id));
+  if (!edge) {
+    // isValidConnection passed, but onConnect can still bail into the
+    // incompatible-connection flow (connector/signal needs an adapter, or there
+    // are zero/multiple adapter matches), leaving a pending UI prompt and no
+    // edge. Clear that pending state and report honestly rather than claiming
+    // a connection that never happened.
+    useSchematicStore.setState({ pendingIncompatibleConnection: null });
+    throw new CommandError(
+      "Connection was not created — these ports are incompatible and need an adapter device between them.",
+    );
+  }
+  return { connected: true, edgeId: edge.id, sourceHandle, targetHandle };
 }
 
 // ---------------------------------------------------------------------------
@@ -192,17 +251,7 @@ const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown
   },
 
   add_device: async (params) => {
-    const { templateId, label, x, y } = params as unknown as AddDeviceParams;
-    if (!templateId) throw new CommandError("templateId is required.");
-    const tpl = resolveTemplate(templateId, await allTemplates());
-    if (!tpl) throw new CommandError(`No template found for "${templateId}". Use search_templates first.`);
-    const position = { x: x ?? 0, y: y ?? 0 };
-    const before = new Set(st().nodes.map((n) => n.id));
-    st().addDevice(tpl, position);
-    const added = st().nodes.find((n) => !before.has(n.id));
-    if (!added) throw new CommandError("Device was not added (no new node appeared).");
-    if (label && label !== tpl.label) st().updateDeviceLabel(added.id, label);
-    return { nodeId: added.id, label: (added.data as DeviceData).label, position };
+    return addDeviceCore(params as unknown as AddDeviceParams, await allTemplates());
   },
 
   set_device_property: (params) => {
@@ -223,39 +272,7 @@ const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown
     return { nodeId, applied, rejected };
   },
 
-  connect_devices: (params) => {
-    const p = params as unknown as ConnectDevicesParams;
-    const sourceNode = requireDevice(p.sourceNodeId);
-    const targetNode = requireDevice(p.targetNodeId);
-    const sourceHandle = resolveHandle(sourceNode, p.sourcePortId, p.sourceFace);
-    const targetHandle = resolveHandle(targetNode, p.targetPortId, p.targetFace);
-    const connection: Connection = {
-      source: p.sourceNodeId,
-      sourceHandle,
-      target: p.targetNodeId,
-      targetHandle,
-    };
-    if (!st().isValidConnection(connection)) {
-      throw new CommandError(
-        `That connection is not valid (incompatible direction/signal, duplicate, or self-connection).`,
-      );
-    }
-    const before = new Set(st().edges.map((e) => e.id));
-    st().onConnect(connection);
-    const edge = st().edges.find((e) => !before.has(e.id));
-    if (!edge) {
-      // isValidConnection passed, but onConnect can still bail into the
-      // incompatible-connection flow (connector/signal needs an adapter, or there
-      // are zero/multiple adapter matches), leaving a pending UI prompt and no
-      // edge. Clear that pending state and report honestly rather than claiming
-      // a connection that never happened.
-      useSchematicStore.setState({ pendingIncompatibleConnection: null });
-      throw new CommandError(
-        "Connection was not created — these ports are incompatible and need an adapter device between them.",
-      );
-    }
-    return { connected: true, edgeId: edge.id, sourceHandle, targetHandle };
-  },
+  connect_devices: (params) => connectDevicesCore(params as unknown as ConnectDevicesParams),
 
   delete_device: (params) => {
     const { nodeId } = params as unknown as DeleteDeviceParams;
@@ -280,6 +297,26 @@ const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown
     if (!plan.ok) throw new CommandError(plan.error);
     st().deleteConnection(plan.removeId);
     return { deleted: true, connectionId };
+  },
+
+  add_devices: async (params) => {
+    const { devices } = (params ?? {}) as unknown as AddDevicesParams;
+    // One template fetch for the whole batch (allTemplates() is cached anyway).
+    const templates = await allTemplates();
+    const outcome = runBatch(devices, MAX_BATCH_ITEMS, (spec: AddDeviceParams) =>
+      addDeviceCore(spec, templates),
+    );
+    if (!outcome.ok) throw new CommandError(outcome.error);
+    return { results: outcome.results, succeeded: outcome.succeeded, failed: outcome.failed };
+  },
+
+  connect_devices_batch: (params) => {
+    const { connections } = (params ?? {}) as unknown as ConnectDevicesBatchParams;
+    const outcome = runBatch(connections, MAX_BATCH_ITEMS, (c: ConnectDevicesParams) =>
+      connectDevicesCore(c),
+    );
+    if (!outcome.ok) throw new CommandError(outcome.error);
+    return { results: outcome.results, succeeded: outcome.succeeded, failed: outcome.failed };
   },
 };
 

--- a/src/mcpBridge.ts
+++ b/src/mcpBridge.ts
@@ -43,6 +43,8 @@ import {
   type CreateRackParams,
   type PlaceDeviceInRackParams,
   type RemoveDeviceFromRackParams,
+  type UpdateNoteParams,
+  type DeleteNoteParams,
   type PortFace,
 } from "./mcp/protocol";
 import {
@@ -53,6 +55,7 @@ import {
   planConnectionRemoval,
   runBatch,
   noteTextToHtml,
+  noteHtmlToText,
   validateCardForSlot,
   validateUPosition,
   validateRackFace,
@@ -95,6 +98,43 @@ function requireDevice(nodeId: string): SchematicNode {
 
 function portSummary(p: Port) {
   return { id: p.id, label: p.label, direction: p.direction, signalType: p.signalType };
+}
+
+/** Compact view of a room (container) node for get_schematic. `parentId`/`position`
+ *  follow the same frame convention as devices — position is room-relative when the room
+ *  is nested inside another room. Size follows the same `measured ?? width ?? style ??
+ *  default` chain the rest of the app uses (snapUtils.nodeRect), so a room whose live
+ *  measured size differs from its style isn't misreported; defaults mirror addRoom (400x300). */
+function roomSummary(n: SchematicNode) {
+  const style = (n.style ?? {}) as { width?: number; height?: number };
+  return {
+    roomId: n.id,
+    label: (n.data as { label?: string }).label,
+    position: n.position,
+    parentId: n.parentId,
+    width: n.measured?.width ?? (n.width as number | undefined) ?? style.width ?? 400,
+    height: n.measured?.height ?? (n.height as number | undefined) ?? style.height ?? 300,
+  };
+}
+
+/** Compact view of a note (sticky-note) node for get_schematic. `text` is a best-effort
+ *  plain-text rendering of the note's stored HTML (see noteHtmlToText). `parentId` is
+ *  reported because a note can be reparented into a room, making `position` room-relative. */
+function noteSummary(n: SchematicNode) {
+  return {
+    noteId: n.id,
+    text: noteHtmlToText((n.data as { html?: string }).html ?? ""),
+    position: n.position,
+    parentId: n.parentId,
+  };
+}
+
+/** Find a note node by id, or throw a readable CommandError (mirrors requireDevice). */
+function requireNote(noteId: string): SchematicNode {
+  const node = st().nodes.find((n) => n.id === noteId);
+  if (!node) throw new CommandError(`No note found with id "${noteId}".`);
+  if (node.type !== "note") throw new CommandError(`Node "${noteId}" is not a note.`);
+  return node;
 }
 
 /** Compact view of a device's modular slot, for get_device. `filled` is the quick
@@ -293,12 +333,18 @@ export const handlers: Record<CommandType, (params: Record<string, unknown>) => 
       target: e.target,
       targetHandle: e.targetHandle,
     }));
+    const rooms = st().nodes.filter((n) => n.type === "room").map(roomSummary);
+    const notes = st().nodes.filter((n) => n.type === "note").map(noteSummary);
     return {
       schematicName: st().schematicName,
       deviceCount: devices.length,
       connectionCount: connections.length,
+      roomCount: rooms.length,
+      noteCount: notes.length,
       devices,
       connections,
+      rooms,
+      notes,
     };
   },
 
@@ -755,6 +801,38 @@ export const handlers: Record<CommandType, (params: Record<string, unknown>) => 
     // so there is nothing to cascade-clean here — and we never delete a user-built shelf.
     st().removeRackPlacement(page.id, placementId);
     return { removed: true, placementId };
+  },
+
+  update_note: (params) => {
+    const { noteId, text } = params as unknown as UpdateNoteParams;
+    requireNote(noteId);
+    if (typeof text !== "string" || text.trim() === "") {
+      throw new CommandError("text is required (a non-empty note).");
+    }
+    const html = noteTextToHtml(text);
+    const current = (requireNote(noteId).data as { html?: string }).html ?? "";
+    // No-op when the content is unchanged — updateNoteHtml does not guard identical writes,
+    // and pushSnapshot() would otherwise add an empty undo step (the editor's own commit
+    // path is likewise gated on `html !== data.html`).
+    if (html === current) {
+      return { noteId, text, changed: false };
+    }
+    // pushSnapshot() makes this a single undo step (updateNoteHtml itself does not push undo,
+    // because the editor calls it on every keystroke and snapshots separately). Text is
+    // XSS-safe via the same noteTextToHtml path add_note uses.
+    st().pushSnapshot();
+    st().updateNoteHtml(noteId, html);
+    return { noteId, text, changed: true };
+  },
+
+  delete_note: (params) => {
+    const { noteId } = params as unknown as DeleteNoteParams;
+    requireNote(noteId);
+    // deleteNode selects only this note and routes through removeSelected (undoable, full
+    // cleanup). Notes have no ports/edges/children, so nothing cascades. delete_device uses
+    // the same path.
+    st().deleteNode(noteId);
+    return { deleted: true, noteId };
   },
 };
 

--- a/src/mcpBridge.ts
+++ b/src/mcpBridge.ts
@@ -400,15 +400,29 @@ function placeDeviceInRackCore(p: PlaceDeviceInRackParams) {
   }
   if (form === "shelf-only") {
     // Shelf-only gear (too small for a direct rack-mount panel) needs a shelf to sit on.
-    // The editor creates that shelf and lets the user position the device on it; doing
-    // that from the bridge would mean auto-creating a shelf whose later cleanup can't be
-    // told apart from a user-built shelf (no provenance flag on the data). Rather than
-    // risk dropping a user's shelf or leaving an orphan, shelf placement stays an editor
-    // task for this slice.
-    throw new CommandError(
-      `Device "${deviceId}" is too small for a direct rack-mount (it needs a shelf). ` +
-        `Add a shelf and place it on the shelf in the editor.`,
-    );
+    // addPlacementSmart auto-creates a 1U shelf + the mounted placement atomically; we stamp
+    // that shelf with provenance (markShelfCreatedByBridge) so remove_device_from_rack can
+    // clean it up later WITHOUT risking a user-built or user-adopted shelf. addPlacementSmart
+    // does no occupancy check, so pre-check the 1U the new shelf would claim.
+    if (!st().isRackSlotAvailable(page.id, rackId, u.u, 1, f.face)) {
+      throw new CommandError(`U${u.u} on the ${f.face} of rack "${rackId}" is occupied — no room for a shelf.`);
+    }
+    const res = st().addPlacementSmart(page.id, rackId, deviceId, u.u, f.face, undefined, /* createdByBridge */ true);
+    if (!res.ok) {
+      throw new CommandError(`Could not place device "${deviceId}" in rack "${rackId}" (${res.reason}).`);
+    }
+    return {
+      placementId: res.placementId,
+      shelfId: res.shelfId,
+      rackId,
+      deviceId,
+      uPosition: u.u,
+      face: f.face,
+      form,
+      // The device's physical height in U (consistent with list_racks). The auto-created shelf
+      // itself claims a single U regardless of how tall the device standing on it is.
+      heightU: inferRackHeightU(data),
+    };
   }
   const heightU = inferRackHeightU(data);
 
@@ -757,7 +771,9 @@ export const handlers: Record<CommandType, (params: Record<string, unknown>) => 
         // place_device_in_rack would reject it for no visible reason.
         accessories: page.accessories
           .filter((a) => a.rackId === r.id)
-          .map((a) => ({ accessoryId: a.id, type: a.type, label: a.label, uPosition: a.uPosition, heightU: a.heightU })),
+          // createdByBridge: this shelf was auto-created by the bridge and not yet adopted by
+          // the user, so remove_device_from_rack will clean it up with its device.
+          .map((a) => ({ accessoryId: a.id, type: a.type, label: a.label, uPosition: a.uPosition, heightU: a.heightU, createdByBridge: !!a.bridgeCreatedForPlacementId })),
       })),
     }));
     return { pageCount: pages.length, pages };
@@ -829,10 +845,23 @@ export const handlers: Record<CommandType, (params: Record<string, unknown>) => 
   remove_device_from_rack: (params) => {
     const { placementId } = params as unknown as RemoveDeviceFromRackParams;
     if (!placementId) throw new CommandError("placementId is required.");
-    const { page } = requirePlacement(placementId);
-    // Remove only the placement (one undo step). The device stays on the schematic. Shelf
-    // accessories are never auto-created by the bridge (shelf-only placement is rejected),
-    // so there is nothing to cascade-clean here — and we never delete a user-built shelf.
+    const { page, placement } = requirePlacement(placementId);
+    // If this device sits on a shelf the bridge auto-created FOR THIS placement, and the user
+    // hasn't adopted that shelf, clean it up along with the device (one undo step). The shelf
+    // is removed ONLY when ALL hold: the placement is shelf-mounted; the shelf still exists;
+    // its provenance is still bound to THIS exact placement (any user edit / second occupant /
+    // page-duplication clears the binding); and this placement is the shelf's sole occupant.
+    // Anything else → remove just the placement, never touching a user/adopted shelf.
+    const shelfId = placement.mountedOnShelfId;
+    if (shelfId) {
+      const shelf = page.accessories.find((a) => a.id === shelfId);
+      const otherOccupants = page.placements.filter((pl) => pl.mountedOnShelfId === shelfId && pl.id !== placementId);
+      if (shelf && shelf.bridgeCreatedForPlacementId === placementId && otherOccupants.length === 0) {
+        st().removeRackAccessoryWithOccupants(page.id, shelfId);
+        return { removed: true, placementId, removedShelfId: shelfId };
+      }
+    }
+    // Remove only the placement (one undo step). The device stays on the schematic.
     st().removeRackPlacement(page.id, placementId);
     return { removed: true, placementId };
   },

--- a/src/mcpBridge.ts
+++ b/src/mcpBridge.ts
@@ -33,12 +33,15 @@ import {
   type DeleteDeviceParams,
   type MoveDeviceParams,
   type DeleteConnectionParams,
+  type CreateRoomParams,
+  type PlaceDeviceInRoomParams,
   type PortFace,
 } from "./mcp/protocol";
 import {
   classifyDeviceProperties,
   resolveHandleFromCandidates,
   validatePosition,
+  validateRoomSize,
   planConnectionRemoval,
   runBatch,
 } from "./mcp/validation";
@@ -317,6 +320,64 @@ const handlers: Record<CommandType, (params: Record<string, unknown>) => unknown
     );
     if (!outcome.ok) throw new CommandError(outcome.error);
     return { results: outcome.results, succeeded: outcome.succeeded, failed: outcome.failed };
+  },
+
+  create_room: (params) => {
+    const { label, x, y, width, height } = params as unknown as CreateRoomParams;
+    if (typeof label !== "string" || label.trim() === "") {
+      throw new CommandError("label is required (a non-empty room name).");
+    }
+    const pos = validatePosition(x, y);
+    if (!pos.ok) throw new CommandError(pos.error);
+    const size = validateRoomSize(width, height);
+    if (!size.ok) throw new CommandError(size.error);
+    const beforeRooms = new Set(st().nodes.filter((n) => n.type === "room").map((n) => n.id));
+    const beforeParents = new Map(deviceNodes().map((n) => [n.id, n.parentId] as const));
+    st().addRoom(label, pos.position, size.size);
+    const room = st().nodes.find((n) => n.type === "room" && !beforeRooms.has(n.id));
+    if (!room) throw new CommandError("Room was not created (no new room node appeared).");
+    // addRoom runs reparentAllDevices, which pulls any existing devices that now fall
+    // inside the new room into it (and rewrites their coords to room-relative). Report
+    // those so the caller knows those devices' positions changed (re-read via get_device
+    // / get_schematic before using their old coordinates).
+    const absorbedDeviceIds = deviceNodes()
+      .filter((n) => n.parentId === room.id && beforeParents.get(n.id) !== room.id)
+      .map((n) => n.id);
+    return {
+      roomId: room.id,
+      label: (room.data as { label?: string }).label ?? label,
+      position: pos.position,
+      size: { width: size.size?.width ?? 400, height: size.size?.height ?? 300 },
+      absorbedDeviceIds,
+    };
+  },
+
+  place_device_in_room: (params) => {
+    const { deviceId, roomId, x, y } = params as unknown as PlaceDeviceInRoomParams;
+    requireDevice(deviceId);
+    const room = st().nodes.find((n) => n.id === roomId);
+    if (!room) throw new CommandError(`No room found with id "${roomId}".`);
+    if (room.type !== "room") throw new CommandError(`Node "${roomId}" is not a room.`);
+    let rel = { x: 16, y: 16 };
+    if (x !== undefined || y !== undefined) {
+      const pos = validatePosition(x, y);
+      if (!pos.ok) throw new CommandError(pos.error);
+      rel = pos.position;
+    }
+    // The store action is atomic and returns whether it actually committed: it mutates
+    // only if the device's center lands inside the requested room, otherwise it changes
+    // nothing. Gate on that boolean (NOT a parentId read-back, which can't tell a
+    // rejected placement of an already-in-this-room device from a real one).
+    const placed = st().placeDeviceInRoom(deviceId, roomId, rel);
+    if (!placed) {
+      const after = st().nodes.find((n) => n.id === deviceId);
+      throw new CommandError(
+        `Device "${deviceId}" could not be placed in room "${roomId}": at the given position ` +
+          `(${rel.x}, ${rel.y} relative to the room) its center falls outside the room or inside a ` +
+          `nested room (current parent: ${after?.parentId ?? "none"}). Adjust x/y or enlarge the room.`,
+      );
+    }
+    return { nodeId: deviceId, roomId, position: rel };
   },
 };
 

--- a/src/mcpBridge.ts
+++ b/src/mcpBridge.ts
@@ -17,6 +17,7 @@ import type { Connection } from "@xyflow/react";
 import { useSchematicStore } from "./store";
 import { getPortAbsolutePositions } from "./snapUtils";
 import { getBundledTemplates, getTemplateById, getCardsByFamily, fetchTemplates } from "./templateApi";
+import { inferRackForm, inferRackHeightU } from "./rackUtils";
 import {
   DEFAULT_BRIDGE_PORT,
   PROTOCOL_VERSION,
@@ -39,6 +40,9 @@ import {
   type ListSlotCardsParams,
   type InstallCardParams,
   type RemoveCardParams,
+  type CreateRackParams,
+  type PlaceDeviceInRackParams,
+  type RemoveDeviceFromRackParams,
   type PortFace,
 } from "./mcp/protocol";
 import {
@@ -50,8 +54,20 @@ import {
   runBatch,
   noteTextToHtml,
   validateCardForSlot,
+  validateUPosition,
+  validateRackFace,
+  validateRackSpec,
 } from "./mcp/validation";
-import type { DeviceData, DeviceTemplate, InstalledSlot, Port, SchematicNode } from "./types";
+import type {
+  DeviceData,
+  DeviceTemplate,
+  InstalledSlot,
+  Port,
+  RackData,
+  RackDevicePlacement,
+  RackElevationPage,
+  SchematicNode,
+} from "./types";
 
 export type BridgeStatus = "off" | "connecting" | "connected" | "error";
 
@@ -104,6 +120,59 @@ function requireSlot(device: SchematicNode, slotId: string): InstalledSlot {
     throw new CommandError(`No slot found with id "${slotId}" on device "${device.id}".`);
   }
   return slot;
+}
+
+/** All rack-elevation pages in the schematic (racks live on their own page type,
+ *  separate from the main device graph). */
+function rackPages(): RackElevationPage[] {
+  return st().pages.filter((p): p is RackElevationPage => p.type === "rack-elevation");
+}
+
+/** Compact view of a rack device placement, resolving the device's current label and
+ *  inferred U height from its node. deviceLabel/heightU are null when the placement
+ *  points at a node that no longer exists. */
+function rackPlacementSummary(pl: RackDevicePlacement) {
+  const data = st().nodes.find((n) => n.id === pl.deviceNodeId)?.data as DeviceData | undefined;
+  return {
+    placementId: pl.id,
+    deviceNodeId: pl.deviceNodeId,
+    deviceLabel: data?.label ?? null,
+    uPosition: pl.uPosition,
+    face: pl.face,
+    halfRackSide: pl.halfRackSide,
+    mountedOnShelfId: pl.mountedOnShelfId,
+    heightU: data ? inferRackHeightU(data) : null,
+  };
+}
+
+/** Resolve the rack-elevation page + rack for a rackId, failing on zero or multiple
+ *  matches rather than guessing. Rack ids are intended to be unique; a duplicate means
+ *  the file is already inconsistent, and silently mutating the first match would risk
+ *  touching the wrong rack. */
+function requireRack(rackId: string): { page: RackElevationPage; rack: RackData } {
+  const matches: { page: RackElevationPage; rack: RackData }[] = [];
+  for (const page of rackPages()) {
+    for (const rack of page.racks) {
+      if (rack.id === rackId) matches.push({ page, rack });
+    }
+  }
+  if (matches.length === 0) throw new CommandError(`No rack found with id "${rackId}". Call list_racks first.`);
+  if (matches.length > 1) throw new CommandError(`Rack id "${rackId}" is ambiguous (matches ${matches.length} racks).`);
+  return matches[0];
+}
+
+/** Resolve the rack-elevation page + placement for a placementId, failing on zero or
+ *  multiple matches (same reasoning as requireRack). */
+function requirePlacement(placementId: string): { page: RackElevationPage; placement: RackDevicePlacement } {
+  const matches: { page: RackElevationPage; placement: RackDevicePlacement }[] = [];
+  for (const page of rackPages()) {
+    for (const placement of page.placements) {
+      if (placement.id === placementId) matches.push({ page, placement });
+    }
+  }
+  if (matches.length === 0) throw new CommandError(`No rack placement found with id "${placementId}". Call list_racks first.`);
+  if (matches.length > 1) throw new CommandError(`Placement id "${placementId}" is ambiguous (matches ${matches.length}).`);
+  return matches[0];
 }
 
 /** The full discoverable set: the live community library (which already has the
@@ -513,6 +582,179 @@ export const handlers: Record<CommandType, (params: Record<string, unknown>) => 
       throw new CommandError(`Card could not be removed from slot "${slotId}".`);
     }
     return { deviceId, slotId, emptied: true };
+  },
+
+  list_racks: () => {
+    const pages = rackPages().map((page) => ({
+      pageId: page.id,
+      label: page.label,
+      racks: page.racks.map((r) => ({
+        rackId: r.id,
+        label: r.label,
+        rackType: r.rackType,
+        heightU: r.heightU,
+        depthMm: r.depthMm,
+        widthClass: r.widthClass,
+        placements: page.placements.filter((pl) => pl.rackId === r.id).map(rackPlacementSummary),
+        // Accessories (shelves, blank/vent panels, etc.) also occupy U positions, so list
+        // them too — otherwise a U that's blocked by, say, a shelf would look free here and
+        // place_device_in_rack would reject it for no visible reason.
+        accessories: page.accessories
+          .filter((a) => a.rackId === r.id)
+          .map((a) => ({ accessoryId: a.id, type: a.type, label: a.label, uPosition: a.uPosition, heightU: a.heightU })),
+      })),
+    }));
+    return { pageCount: pages.length, pages };
+  },
+
+  create_rack: (params) => {
+    const { label, heightU, rackType, depthMm, pageId, pageLabel } = params as unknown as CreateRackParams;
+    const spec = validateRackSpec(rackType, heightU, depthMm);
+    if (!spec.ok) throw new CommandError(spec.error);
+    const rackLabel = typeof label === "string" && label.trim() !== "" ? label.trim() : "Rack";
+
+    // Resolve the target page. An explicit pageId must already exist; otherwise create a
+    // fresh rack page. (Creating a page here is a second undo step — addRackPage and
+    // addRack each push undo — but that only happens on the first rack; coalescing would
+    // need a store change, out of scope.)
+    let targetPageId: string;
+    let createdPage = false;
+    if (pageId !== undefined) {
+      // Fail on zero or multiple matches rather than guessing — addRack applies through
+      // mapElevationPage, which would write to EVERY page sharing this id (same fail-on-
+      // ambiguity rule as requireRack / requirePlacement).
+      const matches = rackPages().filter((p) => p.id === pageId);
+      if (matches.length === 0) {
+        throw new CommandError(`No rack-elevation page found with id "${pageId}". Call list_racks, or omit pageId to create one.`);
+      }
+      if (matches.length > 1) {
+        throw new CommandError(`Page id "${pageId}" is ambiguous (matches ${matches.length} pages).`);
+      }
+      targetPageId = pageId;
+    } else {
+      const newLabel = typeof pageLabel === "string" && pageLabel.trim() !== "" ? pageLabel.trim() : "Rack Elevation";
+      targetPageId = st().addRackPage(newLabel);
+      createdPage = true;
+    }
+
+    // New rack x-position follows the editor: PAGE-LOCAL rack count * 400 (a new page
+    // starts at 0).
+    const page = rackPages().find((p) => p.id === targetPageId)!;
+    const position = { x: page.racks.length * 400, y: 0 };
+
+    const rackId = st().addRack(targetPageId, {
+      label: rackLabel,
+      rackType: spec.rackType,
+      heightU: spec.heightU,
+      depthMm: spec.depthMm,
+      widthClass: "19in",
+      position,
+    });
+    return {
+      pageId: targetPageId,
+      rackId,
+      label: rackLabel,
+      rackType: spec.rackType,
+      heightU: spec.heightU,
+      depthMm: spec.depthMm,
+      createdPage,
+    };
+  },
+
+  place_device_in_rack: (params) => {
+    const { deviceId, rackId, uPosition, face } = params as unknown as PlaceDeviceInRackParams;
+    const node = requireDevice(deviceId);
+    const data = node.data as DeviceData;
+    const { page, rack } = requireRack(rackId);
+    const f = validateRackFace(face);
+    if (!f.ok) throw new CommandError(f.error);
+    const u = validateUPosition(uPosition);
+    if (!u.ok) throw new CommandError(u.error);
+
+    // 2-post frames have no rear face (mirrors the editor's isRackRearBlocked).
+    if (f.face === "rear" && rack.rackType === "open-2post") {
+      throw new CommandError(`Rack "${rackId}" is a 2-post frame, which has no rear face — use face "front".`);
+    }
+
+    // A device is placed in at most one rack at a time: the editor hides "Place in Rack"
+    // once a device is placed and excludes already-placed devices from auto-fill, but the
+    // store does not enforce singularity. Reject a duplicate placement explicitly.
+    for (const p of rackPages()) {
+      const existing = p.placements.find((pl) => pl.deviceNodeId === deviceId);
+      if (existing) {
+        throw new CommandError(
+          `Device "${deviceId}" is already placed in a rack (placement "${existing.id}"). ` +
+            `Remove it first with remove_device_from_rack.`,
+        );
+      }
+    }
+
+    const form = inferRackForm(data);
+    if (form === "oversize") {
+      throw new CommandError(`Device "${deviceId}" is too wide to mount in a 19" rack (oversize).`);
+    }
+    if (form === "shelf-only") {
+      // Shelf-only gear (too small for a direct rack-mount panel) needs a shelf to sit on.
+      // The editor creates that shelf and lets the user position the device on it; doing
+      // that from the bridge would mean auto-creating a shelf whose later cleanup can't be
+      // told apart from a user-built shelf (no provenance flag on the data). Rather than
+      // risk dropping a user's shelf or leaving an orphan, shelf placement stays an editor
+      // task for this slice.
+      throw new CommandError(
+        `Device "${deviceId}" is too small for a direct rack-mount (it needs a shelf). ` +
+          `Add a shelf and place it on the shelf in the editor.`,
+      );
+    }
+    const heightU = inferRackHeightU(data);
+
+    // addPlacementSmart does NOT check occupancy — it appends the placement unconditionally
+    // (only its oversize/no-page/no-device early returns bail). So the bridge MUST pre-check
+    // isRackSlotAvailable here, or two devices could be stacked into the same U range.
+    let preferredHalfRackSide: "left" | "right" | undefined;
+    if (form === "half") {
+      // Pick the exact side that is free per the authoritative occupancy check, then pass
+      // it to addPlacementSmart — its internal side heuristic is weaker (ignores multi-U
+      // overlap, full-width blockers and accessories), so "either side free" alone is not
+      // safe. isRackSlotAvailable(side)=true guarantees its sideTaken(side)=false, so the
+      // side we pass is honored.
+      const leftFree = st().isRackSlotAvailable(page.id, rackId, u.u, heightU, f.face, "left");
+      const rightFree = st().isRackSlotAvailable(page.id, rackId, u.u, heightU, f.face, "right");
+      preferredHalfRackSide = leftFree ? "left" : rightFree ? "right" : undefined;
+      if (!preferredHalfRackSide) {
+        throw new CommandError(`No free half-rack space at U${u.u} on the ${f.face} of rack "${rackId}".`);
+      }
+    } else {
+      // full / unknown — full-width direct placement spanning heightU.
+      if (!st().isRackSlotAvailable(page.id, rackId, u.u, heightU, f.face)) {
+        throw new CommandError(`U${u.u}–${u.u + heightU - 1} on the ${f.face} of rack "${rackId}" is occupied or out of bounds.`);
+      }
+    }
+
+    const res = st().addPlacementSmart(page.id, rackId, deviceId, u.u, f.face, preferredHalfRackSide);
+    if (!res.ok) {
+      throw new CommandError(`Could not place device "${deviceId}" in rack "${rackId}" (${res.reason}).`);
+    }
+    return {
+      placementId: res.placementId,
+      rackId,
+      deviceId,
+      uPosition: u.u,
+      face: f.face,
+      form,
+      heightU,
+      halfRackSide: preferredHalfRackSide,
+    };
+  },
+
+  remove_device_from_rack: (params) => {
+    const { placementId } = params as unknown as RemoveDeviceFromRackParams;
+    if (!placementId) throw new CommandError("placementId is required.");
+    const { page } = requirePlacement(placementId);
+    // Remove only the placement (one undo step). The device stays on the schematic. Shelf
+    // accessories are never auto-created by the bridge (shelf-only placement is rejected),
+    // so there is nothing to cascade-clean here — and we never delete a user-built shelf.
+    st().removeRackPlacement(page.id, placementId);
+    return { removed: true, placementId };
   },
 };
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -300,6 +300,13 @@ interface SchematicState {
   removeSelected: () => void;
   deleteNode: (nodeId: string) => void;
   deleteNodeAndChildren: (nodeId: string) => void;
+  /** Reposition a single node within its current parent (one undo step). Does not
+   *  reparent — used by the MCP bridge's move_device tool. */
+  moveDevice: (nodeId: string, position: { x: number; y: number }) => void;
+  /** Remove a single connection by id via the standard removeSelected path (so bundle
+   *  GC, junction + waypoint reconciliation all run). Used by the bridge's
+   *  delete_connection tool. */
+  deleteConnection: (connectionId: string) => void;
   copySelected: () => void;
   pasteClipboard: () => void;
   alignSelectedNodes: (op: AlignOperation) => void;
@@ -1754,6 +1761,48 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
     set({
       nodes: get().nodes.map((n) => ({ ...n, selected: n.id === nodeId })),
       edges: get().edges.map((e) => ({ ...e, selected: false })),
+    });
+    get().removeSelected();
+  },
+
+  moveDevice: (nodeId, position) => {
+    const state = get();
+    if (!state.nodes.some((n) => n.id === nodeId)) return;
+    pushUndo({ nodes: state.nodes, edges: state.edges });
+    // #182: keep stub labels glued to the moved device. Clear `placed` on its connected
+    // (non-user-positioned) stub labels so StubLabelNode.tryPlace re-follows the moved
+    // port instead of leaving them stranded with a dogleg. Mirrors the drag-stop path in
+    // App.tsx so an MCP move_device behaves like a drag.
+    const stubIds = new Set(state.nodes.filter((n) => n.type === "stub-label").map((n) => n.id));
+    const followStubs = new Set<string>();
+    for (const e of state.edges) {
+      const srcStub = stubIds.has(e.source);
+      const tgtStub = stubIds.has(e.target);
+      if (srcStub === tgtStub) continue; // not a stub leg
+      const devEnd = srcStub ? e.target : e.source;
+      if (devEnd === nodeId) followStubs.add(srcStub ? e.source : e.target);
+    }
+    set({
+      nodes: state.nodes.map((n) => {
+        if (n.id === nodeId) return { ...n, position };
+        if (followStubs.has(n.id) && n.type === "stub-label") {
+          const d = n.data as import("./types").StubLabelData;
+          if (!d.userMoved && d.placed === true) return { ...n, data: { ...d, placed: false } };
+        }
+        return n;
+      }),
+    });
+    get().saveToLocalStorage();
+  },
+
+  deleteConnection: (connectionId: string) => {
+    const state = get();
+    if (!state.edges.some((e) => e.id === connectionId)) return;
+    // Select only this edge, deselect everything else, then removeSelected — the same
+    // path the UI uses, so undo, bundle GC, junction + waypoint reconciliation all run.
+    set({
+      nodes: state.nodes.map((n) => (n.selected ? { ...n, selected: false } : n)),
+      edges: state.edges.map((e) => ({ ...e, selected: e.id === connectionId })),
     });
     get().removeSelected();
   },

--- a/src/store.ts
+++ b/src/store.ts
@@ -343,7 +343,7 @@ interface SchematicState {
   setEditingNodeId: (id: string | null) => void;
   setCreatingNodeId: (id: string | null) => void;
   createAndEditDevice: (template: DeviceTemplate, position: { x: number; y: number }) => void;
-  addRoom: (label: string, position: { x: number; y: number }) => void;
+  addRoom: (label: string, position: { x: number; y: number }, size?: { width: number; height: number }) => void;
   updateRoomLabel: (nodeId: string, label: string) => void;
   updateRoom: (nodeId: string, data: import("./types").RoomData) => void;
   updateAnnotation: (nodeId: string, data: Partial<import("./types").AnnotationData>) => void;
@@ -352,6 +352,15 @@ interface SchematicState {
   addNote: (position: { x: number; y: number }) => void;
   updateNoteHtml: (nodeId: string, html: string) => void;
   reparentNode: (nodeId: string, absolutePosition: { x: number; y: number }, options?: { skipUndo?: boolean }) => void;
+  /** Place a device inside a specific room (set parentId) by routing through
+   *  reparentNode, so parentId stays consistent with geometry. Atomic: if the
+   *  device's center would not land inside `roomId` (outside its bounds, or inside a
+   *  nested room), nothing changes. `relativePosition` is relative to the room's
+   *  top-left and defaults to (16,16). Returns true only if the device was actually
+   *  placed (committed), false on any no-op/reject — so a caller can't mistake an
+   *  unchanged "already in this room" device for a successful placement. Used by the
+   *  bridge's place_device_in_room tool. */
+  placeDeviceInRoom: (nodeId: string, roomId: string, relativePosition?: { x: number; y: number }) => boolean;
   /** Re-evaluate room membership for every non-room node. Used after a room is
    *  created, resized, or moved so devices get parented/unparented to match
    *  the new layout. */
@@ -1160,6 +1169,50 @@ function findBestEnclosingRoom(
   return best;
 }
 
+/** The geometric center of a node placed at `absolutePosition`, using the same
+ *  measured-size fallbacks reparentNode and reparentAllDevices rely on (room
+ *  400x300, device 144x48). Shared so any room-membership pre-check stays in
+ *  lockstep with the reparent that follows it. */
+function nodeCenterFromAbsolute(
+  node: SchematicNode,
+  absolutePosition: { x: number; y: number },
+): { x: number; y: number } {
+  const isRoom = node.type === "room";
+  const w = node.measured?.width ?? (isRoom ? 400 : 144);
+  const h = node.measured?.height ?? (isRoom ? 300 : 48);
+  return { x: absolutePosition.x + w / 2, y: absolutePosition.y + h / 2 };
+}
+
+/** #182: when a device moves, clear `placed` on its connected auto-placed stub
+ *  labels so they re-follow the device's port instead of stranding with a dogleg.
+ *  A stub leg is an edge with exactly one stub-label end; the other end is the
+ *  device. User-positioned stub labels are left alone. Returns a new nodes array
+ *  (or the same array when nothing needs clearing). Shared by moveDevice and
+ *  placeDeviceInRoom so the "which stubs follow" logic lives in one place. */
+function reanchorConnectedStubLabels(
+  nodes: SchematicNode[],
+  edges: ConnectionEdge[],
+  deviceId: string,
+): SchematicNode[] {
+  const stubIds = new Set(nodes.filter((n) => n.type === "stub-label").map((n) => n.id));
+  const followStubs = new Set<string>();
+  for (const e of edges) {
+    const srcStub = stubIds.has(e.source);
+    const tgtStub = stubIds.has(e.target);
+    if (srcStub === tgtStub) continue; // not a stub leg
+    const devEnd = srcStub ? e.target : e.source;
+    if (devEnd === deviceId) followStubs.add(srcStub ? e.source : e.target);
+  }
+  if (followStubs.size === 0) return nodes;
+  return nodes.map((n) => {
+    if (followStubs.has(n.id) && n.type === "stub-label") {
+      const d = n.data as import("./types").StubLabelData;
+      if (!d.userMoved && d.placed === true) return { ...n, data: { ...d, placed: false } };
+    }
+    return n;
+  });
+}
+
 function getPortFromHandle(
   nodes: SchematicNode[],
   nodeId: string,
@@ -1769,28 +1822,11 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
     const state = get();
     if (!state.nodes.some((n) => n.id === nodeId)) return;
     pushUndo({ nodes: state.nodes, edges: state.edges });
-    // #182: keep stub labels glued to the moved device. Clear `placed` on its connected
-    // (non-user-positioned) stub labels so StubLabelNode.tryPlace re-follows the moved
-    // port instead of leaving them stranded with a dogleg. Mirrors the drag-stop path in
-    // App.tsx so an MCP move_device behaves like a drag.
-    const stubIds = new Set(state.nodes.filter((n) => n.type === "stub-label").map((n) => n.id));
-    const followStubs = new Set<string>();
-    for (const e of state.edges) {
-      const srcStub = stubIds.has(e.source);
-      const tgtStub = stubIds.has(e.target);
-      if (srcStub === tgtStub) continue; // not a stub leg
-      const devEnd = srcStub ? e.target : e.source;
-      if (devEnd === nodeId) followStubs.add(srcStub ? e.source : e.target);
-    }
+    // #182: keep stub labels glued to the moved device (mirrors the drag-stop path in
+    // App.tsx so an MCP move_device behaves like a drag).
+    const reanchored = reanchorConnectedStubLabels(state.nodes, state.edges, nodeId);
     set({
-      nodes: state.nodes.map((n) => {
-        if (n.id === nodeId) return { ...n, position };
-        if (followStubs.has(n.id) && n.type === "stub-label") {
-          const d = n.data as import("./types").StubLabelData;
-          if (!d.userMoved && d.placed === true) return { ...n, data: { ...d, placed: false } };
-        }
-        return n;
-      }),
+      nodes: reanchored.map((n) => (n.id === nodeId ? { ...n, position } : n)),
     });
     get().saveToLocalStorage();
   },
@@ -2944,7 +2980,7 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
     set({ editingNodeId: newNodeId, creatingNodeId: newNodeId });
   },
 
-  addRoom: (label, position) => {
+  addRoom: (label, position, size) => {
     const state = get();
     pushUndo({ nodes: state.nodes, edges: state.edges });
     const newRoom: SchematicNode = {
@@ -2952,7 +2988,7 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
       type: "room",
       position,
       data: { label },
-      style: { width: 400, height: 300 },
+      style: { width: size?.width ?? 400, height: size?.height ?? 300 },
       selected: true,
       zIndex: -1,
     };
@@ -3108,12 +3144,9 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
 
     const nodeMap = new Map(state.nodes.map((n) => [n.id, n]));
     const isRoom = node.type === "room";
-    const nodeW = node.measured?.width ?? (isRoom ? 400 : 144);
-    const nodeH = node.measured?.height ?? (isRoom ? 300 : 48);
-    const centerX = absolutePosition.x + nodeW / 2;
-    const centerY = absolutePosition.y + nodeH / 2;
+    const center = nodeCenterFromAbsolute(node, absolutePosition);
 
-    const targetRoom = findBestEnclosingRoom(nodeId, isRoom, centerX, centerY, state.nodes, nodeMap);
+    const targetRoom = findBestEnclosingRoom(nodeId, isRoom, center.x, center.y, state.nodes, nodeMap);
 
     const currentParent = node.parentId;
     const newParent = targetRoom?.id;
@@ -3149,6 +3182,52 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
 
     set({ nodes: updated });
     get().saveToLocalStorage();
+  },
+
+  placeDeviceInRoom: (nodeId, roomId, relativePosition) => {
+    const state = get();
+    const nodeMap = new Map(state.nodes.map((n) => [n.id, n]));
+    const room = nodeMap.get(roomId);
+    const device = nodeMap.get(nodeId);
+    // Unknown room/device, or the target isn't a room -> no-op. Return false so the
+    // caller never mistakes a non-placement for success (the read-back alone can't tell
+    // a rejected placement of an already-in-this-room device from a real one).
+    if (!room || room.type !== "room" || !device) return false;
+
+    const roomAbs = getAbsolutePosition(roomId, nodeMap);
+    const rel = relativePosition ?? { x: 16, y: 16 };
+    const absPos = { x: roomAbs.x + rel.x, y: roomAbs.y + rel.y };
+
+    // PRE-CHECK (atomicity): will the device's center land in THIS room? Use the same
+    // center math + enclosing-room logic reparentNode will use, so a success here
+    // guarantees the commit below reparents into roomId. If the target room would not
+    // win (the point is outside it, or inside a smaller nested room), change NOTHING —
+    // no undo snapshot, no set, no save — and return false so a rejected placement has
+    // no side effects and is never reported as success.
+    const center = nodeCenterFromAbsolute(device, absPos);
+    const winner = findBestEnclosingRoom(nodeId, false, center.x, center.y, state.nodes, nodeMap);
+    if (winner?.id !== roomId) return false;
+
+    // Idempotent: already in this room at exactly this position -> the desired end state
+    // already holds, so report success without mutating or pushing an empty undo step.
+    if (device.parentId === roomId && device.position.x === rel.x && device.position.y === rel.y) {
+      return true;
+    }
+
+    // COMMIT: re-anchor connected stub labels (as a drag/move would), move the device
+    // to the absolute target as a temporarily top-level node, then let reparentNode do
+    // the geometric reparent + relative-coord conversion + parent-first sort. Clearing
+    // parentId first avoids reparentNode's "parent unchanged" early-return.
+    pushUndo({ nodes: state.nodes, edges: state.edges });
+    const reanchored = reanchorConnectedStubLabels(state.nodes, state.edges, nodeId);
+    set({
+      nodes: reanchored.map((n) =>
+        n.id === nodeId ? { ...n, parentId: undefined, position: absPos } : n,
+      ),
+    });
+    get().reparentNode(nodeId, absPos, { skipUndo: true });
+    get().saveToLocalStorage();
+    return true;
   },
 
   reparentAllDevices: (options) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -700,6 +700,7 @@ interface SchematicState {
     uPosition: number,
     face: "front" | "rear",
     preferredHalfRackSide?: "left" | "right",
+    markShelfCreatedByBridge?: boolean,
   ) => { ok: true; placementId: string; shelfId?: string } | { ok: false; reason: "oversize" | "no-page" | "no-device" };
   removeRackPlacement: (pageId: string, placementId: string) => void;
   updateRackPlacement: (pageId: string, placementId: string, patch: Partial<RackDevicePlacement>) => void;
@@ -4219,7 +4220,7 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
     return id;
   },
 
-  addPlacementSmart: (pageId, rackId, deviceNodeId, uPosition, face, preferredHalfRackSide) => {
+  addPlacementSmart: (pageId, rackId, deviceNodeId, uPosition, face, preferredHalfRackSide, markShelfCreatedByBridge) => {
     const state = get();
     const page = state.pages.find((p) => p.id === pageId && p.type === "rack-elevation") as RackElevationPage | undefined;
     if (!page) return { ok: false, reason: "no-page" };
@@ -4247,6 +4248,10 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
         uPosition,
         heightU: 1,
         face,
+        // Bridge-created shelves are stamped with the placement they were made for, atomically
+        // here (same set/pushUndo) so there is no window where the shelf persists unflagged.
+        // Editor drag-drop passes no flag, so user-created shelves stay unmarked.
+        bridgeCreatedForPlacementId: markShelfCreatedByBridge ? placementId : undefined,
       };
       const newW = device.widthMm ?? innerWMm;
       // Center on the shelf when there's room; otherwise pin to the left rail.
@@ -4318,10 +4323,20 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
 
   updateRackPlacement: (pageId, placementId, patch) => {
     const state = get();
+    // A user editing/moving a shelf-mounted device adopts/detaches the shelves involved, so
+    // drop bridge auto-cleanup provenance on BOTH: the shelf this placement was the bridge's
+    // original occupant of (source detach), AND any shelf it is being (re)mounted onto via a
+    // cross-shelf drag (destination adoption — the user just put a device on it). Same single
+    // chokepoint + non-undoing caveat as updateRackAccessory.
+    const destShelfId = patch.mountedOnShelfId;
     set({
       pages: mapElevationPage(state.pages, pageId, (p) => ({
         ...p,
         placements: p.placements.map((pl) => pl.id === placementId ? { ...pl, ...patch } : pl),
+        accessories: p.accessories.map((a) =>
+          (a.bridgeCreatedForPlacementId === placementId || (destShelfId != null && a.id === destShelfId))
+            ? { ...a, bridgeCreatedForPlacementId: undefined }
+            : a),
       })),
     });
     get().saveToLocalStorage();
@@ -4355,7 +4370,13 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
     set({
       pages: mapElevationPage(state.pages, pageId, (p) => ({
         ...p,
-        accessories: p.accessories.map((a) => a.id === accessoryId ? { ...a, ...patch } : a),
+        // Any user edit (rename/resize/depth/move) marks the shelf as adopted, so the MCP
+        // bridge will never auto-remove it. Clearing bridgeCreatedForPlacementId here is the
+        // single chokepoint for that (all editor shelf-edit paths route through this action;
+        // the bridge never calls it). NOTE: like the rest of updateRackAccessory this does not
+        // pushUndo, so the provenance clear is not reverted by undo — acceptable because it
+        // only ever loosens auto-cleanup (an un-adopted shelf can still be removed manually).
+        accessories: p.accessories.map((a) => a.id === accessoryId ? { ...a, ...patch, bridgeCreatedForPlacementId: undefined } : a),
       })),
     });
     get().saveToLocalStorage();
@@ -4431,7 +4452,13 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
       shelfOffsetMm: offset,
     };
     set({
-      pages: mapElevationPage(state.pages, pageId, (p) => ({ ...p, placements: [...p.placements, placement] })),
+      pages: mapElevationPage(state.pages, pageId, (p) => ({
+        ...p,
+        placements: [...p.placements, placement],
+        // A user manually stacking a device onto this shelf adopts it — drop the bridge's
+        // auto-cleanup provenance so the shelf is never auto-removed out from under them.
+        accessories: p.accessories.map((a) => a.id === shelfId ? { ...a, bridgeCreatedForPlacementId: undefined } : a),
+      })),
       undoSize: undoStack.length, redoSize: 0,
     });
     get().saveToLocalStorage();
@@ -4609,6 +4636,9 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
         ...a,
         id: nid,
         rackId: rackIdMap.get(a.rackId) ?? a.rackId,
+        // The provenance binding points at the source page's placement id, which doesn't exist
+        // on the copy — drop it so a duplicated shelf is a plain (non-bridge) shelf.
+        bridgeCreatedForPlacementId: undefined,
       };
     });
     const newPlacements = src.placements.map((pl) => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -694,6 +694,14 @@ export interface RackAccessory {
   /** Usable depth for shelf-mounted gear in mm (only meaningful when type === "shelf").
    *  Defaults to ~60% of rack.depthMm when unset. */
   shelfDepthMm?: number;
+  /** Set when the MCP bridge auto-created this shelf to hold a shelf-only device; its value
+   *  is the id of that original placement. Its PRESENCE marks the shelf as bridge-created AND
+   *  not-yet-touched-by-the-user — `remove_device_from_rack` will auto-remove the shelf only
+   *  when unracking that exact placement while it is the shelf's sole occupant. Any user edit
+   *  (rename/resize/depth/move via `updateRackAccessory`, adding a second device via
+   *  `addShelfMountedDevice`, or page duplication) clears this field, so an adopted shelf is
+   *  never auto-removed. */
+  bridgeCreatedForPlacementId?: string;
 }
 
 export interface RackElevationPage {


### PR DESCRIPTION
## What

Follow-up to #223 (the live MCP bridge — thanks for merging it!). That PR noted the follow-on slices were already built on my fork and I'd send them once it landed. This brings the rest of the tool surface up to what I've been running:

- **Editing / layout** — `move_device`, `delete_connection`; `parentId` added to the read output
- **Batch ops** — `add_devices`, `connect_devices_batch`, `install_card_batch`, `place_device_in_rack_batch` (best-effort, per-item `{index, ok, result|error}`)
- **Rooms** — `create_room`, `place_device_in_room`
- **Notes** — `add_note`, `update_note`, `delete_note`; rooms + notes now also returned by `get_schematic`
- **Modular chassis** — `list_slot_cards`, `install_card`, `remove_card`
- **Rack elevations** — `list_racks`, `create_rack`, `place_device_in_rack`, `remove_device_from_rack` (incl. shelf-only gear, with shelf auto-create + provenance so an unrack cleans up after itself)
- **Guidance** — server `instructions` + 3 companion prompts (`build-schematic`, `rack-elevation`, `modular-chassis`) so any MCP client, not just Claude Code, gets the playbooks

Same architecture and safety model as #223: every tool routes through **existing store actions**, so undo / autosave / validation / auto-routing all keep working; the shared wire protocol stays the single source of truth (the server imports a generated copy so the two sides can't drift); the bridge is still opt-in and localhost-only. **No schema or version bump.**

## On packaging

#223 offered these as *separate* PRs. Since it merged cleanly and you've already built on top, I bundled them into this one PR to save six review round-trips — but **each slice is its own commit** (10 commits, one per slice), so you can read or merge them commit-by-commit. Happy to split it back into a stack if you'd prefer that.

## Notes

- Two small store bug-fixes that rode inside these slices on my fork — the slot descendant-match fix and the `duplicateRackPage` shelf remap — I already sent standalone as #221 / #222 (merged), so they're **excluded here** to avoid duplication. This branch is cut fresh off current `master`.
- Gates on top of current `master`, all green: `tsc -b` + `vite build`, eslint (0 errors), `vitest` (379 passing), routing baseline check (byte-identical), standalone `mcp-server` build + tests, docs build.
- Known Beta limits (documented in the tool descriptions): defining new chassis slots is still editor-only, as are rack accessories beyond shelves.
