### PR TITLE
fix: preserve the saved schematic when autosave fails to load

### DIFF
--- a/src/__tests__/store.dataloss.test.ts
+++ b/src/__tests__/store.dataloss.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CURRENT_SCHEMA_VERSION } from "../migrations";
+import type { SchematicFile, SchematicNode } from "../types";
+
+/**
+ * Regression tests for the autosave data-loss guard in loadFromLocalStorage.
+ *
+ * Bug: when a non-empty saved schematic failed to load (bad JSON / migration),
+ * the catch armed `hydrated` and returned silently, so the next edit's autosave
+ * overwrote the still-recoverable saved copy with the blank initial state.
+ * Fix: on a pre-commit load failure leave autosave disabled (so the saved copy
+ * is preserved) and surface an error; re-arm autosave on New / Open / Import.
+ */
+
+const STORAGE_KEY = "easyschematic-autosave";
+
+function makeLocalStorage(initial: Record<string, string> = {}) {
+  const backing: Record<string, string> = { ...initial };
+  return {
+    backing,
+    getItem: vi.fn((k: string) => (k in backing ? backing[k] : null)),
+    setItem: vi.fn((k: string, v: string) => { backing[k] = v; }),
+    removeItem: vi.fn((k: string) => { delete backing[k]; }),
+    clear: vi.fn(() => { for (const k of Object.keys(backing)) delete backing[k]; }),
+  };
+}
+
+// Node 18+ exposes globalThis.crypto.randomUUID (used by addToast); shim if absent.
+beforeEach(() => {
+  vi.resetModules();
+  if (!globalThis.crypto?.randomUUID) {
+    vi.stubGlobal("crypto", { randomUUID: () => "test-" + Math.random().toString(36).slice(2) });
+  }
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("loadFromLocalStorage — data-loss guard", () => {
+  it("does not overwrite a corrupt saved schematic and surfaces an error", async () => {
+    const corrupt = "{ this is not valid json";
+    const ls = makeLocalStorage({ [STORAGE_KEY]: corrupt });
+    vi.stubGlobal("localStorage", ls);
+
+    const { useSchematicStore } = await import("../store");
+
+    // Corrupt data fails to load (JSON.parse throws → the pre-commit catch).
+    expect(useSchematicStore.getState().loadFromLocalStorage()).toBe(false);
+
+    // The failure is surfaced to the user, not swallowed silently.
+    expect(useSchematicStore.getState().toasts.some((t) => t.type === "error")).toBe(true);
+
+    // A subsequent autosave must be a no-op — the saved copy stays intact.
+    ls.setItem.mockClear();
+    useSchematicStore.getState().saveToLocalStorage();
+    expect(ls.setItem).not.toHaveBeenCalled();
+    expect(ls.backing[STORAGE_KEY]).toBe(corrupt);
+  });
+
+  it("re-arms autosave via newSchematic after a failed load", async () => {
+    // Non-empty broken blob → the synchronous failure path (no async demo import),
+    // so a later setItem can only come from the explicit newSchematic() re-arm.
+    const ls = makeLocalStorage({ [STORAGE_KEY]: "{ broken" });
+    vi.stubGlobal("localStorage", ls);
+
+    const { useSchematicStore } = await import("../store");
+    expect(useSchematicStore.getState().loadFromLocalStorage()).toBe(false);
+
+    ls.setItem.mockClear();
+    useSchematicStore.getState().newSchematic();
+    expect(ls.setItem).toHaveBeenCalled();
+  });
+
+  it("re-arms autosave via importFromJSON after a failed load", async () => {
+    // Same synchronous failure path; then opening/importing a valid schematic
+    // (the funnel for file open, share links, and cloud open) must re-arm autosave.
+    const ls = makeLocalStorage({ [STORAGE_KEY]: "{ broken" });
+    vi.stubGlobal("localStorage", ls);
+
+    const { useSchematicStore } = await import("../store");
+    expect(useSchematicStore.getState().loadFromLocalStorage()).toBe(false);
+
+    ls.setItem.mockClear();
+    const doc: SchematicFile = { version: CURRENT_SCHEMA_VERSION, name: "Recovered", nodes: [], edges: [] };
+    useSchematicStore.getState().importFromJSON(doc);
+    expect(ls.setItem).toHaveBeenCalled();
+    expect(ls.backing[STORAGE_KEY]).toContain("Recovered");
+  });
+
+  it("re-arms autosave via importCsvData after a failed load", async () => {
+    // The CSV cable-schedule wizard is a fourth way to put real content on the
+    // canvas. It merges into the current document rather than replacing it, so
+    // it is easy to overlook — but after a failed hydrate it must re-arm autosave
+    // too, or the imported rows are never persisted.
+    const ls = makeLocalStorage({ [STORAGE_KEY]: "{ broken" });
+    vi.stubGlobal("localStorage", ls);
+
+    const { useSchematicStore } = await import("../store");
+    expect(useSchematicStore.getState().loadFromLocalStorage()).toBe(false);
+
+    const node = {
+      id: "dev-1",
+      type: "device",
+      position: { x: 0, y: 0 },
+      data: { label: "Imported Device" },
+    } as unknown as SchematicNode;
+
+    ls.setItem.mockClear();
+    useSchematicStore.getState().importCsvData([node], []);
+    expect(ls.setItem).toHaveBeenCalled();
+    // Assert on the persisted bytes, not just that a write happened — a regression
+    // that re-armed autosave but serialized stale/blank state would still "save".
+    expect(ls.backing[STORAGE_KEY]).toContain("Imported Device");
+  });
+
+  it("persists an imported schematic even when the post-import counter sync throws", async () => {
+    // importFromJSON's side-effects are guarded separately: a malformed `pages`
+    // shape must not throw past the autosave. Otherwise importing to recover from
+    // a failed hydrate leaves nothing on disk, and a reload before the next edit
+    // drops the user back onto the old unreadable blob.
+    const ls = makeLocalStorage({ [STORAGE_KEY]: "{ broken" });
+    vi.stubGlobal("localStorage", ls);
+
+    const { useSchematicStore } = await import("../store");
+    expect(useSchematicStore.getState().loadFromLocalStorage()).toBe(false);
+
+    ls.setItem.mockClear();
+    useSchematicStore.getState().importFromJSON({
+      version: CURRENT_SCHEMA_VERSION,
+      name: "Recovered With Bad Pages",
+      nodes: [],
+      edges: [],
+      pages: [{ id: "printsheet-1", type: "print-sheet", viewports: 5 }],
+    } as unknown as SchematicFile);
+
+    expect(ls.backing[STORAGE_KEY]).toContain("Recovered With Bad Pages");
+  });
+
+  it("keeps a loaded schematic and armed autosave when the post-load side-effect throws", async () => {
+    // Guards the ORDERING: `hydrated` is armed after the state commit but before
+    // syncRackCounters, and that side-effect is wrapped. A non-iterable `viewports`
+    // makes syncRackCounters throw (the #176 shape). The schematic must still count
+    // as loaded and autosave must stay ON — otherwise a partially-bad but perfectly
+    // recoverable file would be mislabelled a failed load and stop autosaving.
+    const blob = JSON.stringify({
+      version: CURRENT_SCHEMA_VERSION,
+      name: "Has Pages",
+      nodes: [],
+      edges: [],
+      pages: [{ id: "printsheet-1", type: "print-sheet", viewports: 5 }],
+    });
+    const ls = makeLocalStorage({ [STORAGE_KEY]: blob });
+    vi.stubGlobal("localStorage", ls);
+
+    const { useSchematicStore } = await import("../store");
+
+    // Loaded successfully despite the side-effect throwing.
+    expect(useSchematicStore.getState().loadFromLocalStorage()).toBe(true);
+    expect(useSchematicStore.getState().schematicName).toBe("Has Pages");
+
+    // Autosave is armed, so the user's next edit persists normally.
+    ls.setItem.mockClear();
+    useSchematicStore.getState().saveToLocalStorage();
+    expect(ls.setItem).toHaveBeenCalled();
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -5272,9 +5272,22 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
             distanceSettings: data.distanceSettings ?? undefined,
             loadSeq: get().loadSeq + 1,
           });
-          if (data.pages?.length) syncRackCounters(data.pages);
+          // Same ordering as the main load path: arm autosave before the
+          // post-load side-effect so a throw can't disable autosave or escape as
+          // an unhandled rejection.
           hydrated = true;
+          try {
+            if (data.pages?.length) syncRackCounters(data.pages);
+          } catch (err) {
+            console.error("Post-load side-effect failed (demo still loaded):", err);
+          }
           get().saveToLocalStorage();
+        }).catch((err) => {
+          // First-run only: localStorage was empty, so there is no saved copy to
+          // protect. Arm autosave anyway so the visitor's own edits on the blank
+          // canvas still persist, and log the demo-load failure so it isn't silent.
+          hydrated = true;
+          console.error("Failed to load the demo schematic:", err);
         });
         return false;
       }
@@ -5359,11 +5372,27 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
         cloudSavedAt: parsed.cloudSavedAt ?? null,
         loadSeq: get().loadSeq + 1,
       });
-      if (data.pages?.length) syncRackCounters(data.pages);
+      // The schematic is committed to state above; arm autosave here, BEFORE the
+      // post-load side-effect, so a throw below can neither strand a loaded
+      // schematic with autosave off nor mislabel it as a failed load (#176).
       hydrated = true;
+      try {
+        if (data.pages?.length) syncRackCounters(data.pages);
+      } catch (err) {
+        console.error("Post-load side-effect failed (schematic still loaded):", err);
+      }
       return true;
-    } catch {
-      hydrated = true;
+    } catch (err) {
+      // Reaching here means the load failed BEFORE the schematic was committed to
+      // state (bad JSON / migration / heal), so the canvas is still blank. Leave
+      // `hydrated` false so autosave stays a no-op and can't overwrite the saved
+      // copy still on disk with this empty state. Surface the failure instead of
+      // blanking silently; New / Open / Import re-arm autosave for a fresh document.
+      console.error("Failed to load saved schematic from localStorage:", err);
+      get().addToast(
+        "Couldn't open your last saved schematic. Autosave is paused so your saved copy isn't overwritten — starting a new schematic, opening a file, or importing one resumes it.",
+        "error",
+      );
       return false;
     }
   },
@@ -5540,15 +5569,28 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
       fileHandle: null,
       loadSeq: get().loadSeq + 1,
     });
+    // Re-arm autosave for this just-loaded document. If the initial localStorage
+    // hydrate failed, `hydrated` is still false; without this an opened / imported
+    // schematic (file, share link, or cloud) would silently never autosave.
+    hydrated = true;
     // Post-load side-effects (ID counters + persistence). The schematic is
     // already committed to state above; a failure here must NOT propagate, or a
     // caller's try/catch mislabels a successfully-loaded file as invalid (#176).
+    // They are guarded SEPARATELY so they can't take each other down: sharing one
+    // try meant a bad `pages` shape threw past the persist, leaving the imported
+    // schematic unsaved until the next edit — and on the recovery path (import
+    // after a failed hydrate) a reload before that edit would drop the user back
+    // onto the old unreadable blob.
     try {
       if (data.pages?.length) syncRackCounters(data.pages);
+    } catch (err) {
+      console.error("Post-import counter sync failed (schematic still loaded):", err);
+    }
+    try {
       saveCategoryOrder(data.categoryOrder ?? null);
       get().saveToLocalStorage();
     } catch (err) {
-      console.error("Post-import side-effect failed (schematic still loaded):", err);
+      console.error("Post-import persist failed (schematic still loaded):", err);
     }
   },
 
@@ -5566,6 +5608,10 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
       nodes: renumberNodes(mergedNodes),
       edges: mergedEdges,
     });
+    // A CSV import establishes real content the same way New / Open / Import do,
+    // so it re-arms autosave too. Without this, importing after a failed initial
+    // hydrate would leave `hydrated` false and every save below a silent no-op.
+    hydrated = true;
     get().saveToLocalStorage();
   },
 
@@ -5635,6 +5681,9 @@ export const useSchematicStore = create<SchematicState>((set, get) => ({
         loadSeq: get().loadSeq + 1,
       });
     }
+    // Establishing a blank / template document also re-arms autosave in case the
+    // initial localStorage hydrate had failed (which leaves `hydrated` false).
+    hydrated = true;
     get().saveToLocalStorage();
   },
 


### PR DESCRIPTION
### The bug

`saveToLocalStorage` is gated by a single module flag: `if (!hydrated) return`. `loadFromLocalStorage` wraps parse + migrate + heal + the state commit in one `try`, and its `catch` set `hydrated = true` and returned silently.

So if a **non-empty** saved blob threw *before* the schematic was committed — bad JSON, a migration error, a heal error — the user landed on a **blank canvas with autosave armed**. Their next edit then overwrote the still-recoverable saved copy with empty state.

Silent, and unrecoverable once it happens. Worth noting it's self-inflicted on reload: the blob that failed to load is usually still perfectly good data that just needs a fix, and the old behaviour destroyed it.

### The fix

- **Pre-commit failure leaves `hydrated` false**, so autosave stays a no-op and the on-disk copy survives. The error is logged and surfaced as a toast instead of blanking silently.
- **`hydrated` is armed right after the state commit, before `syncRackCounters`**, and that side-effect gets its own `try/catch` — the same pattern already used in `importFromJSON` for #176. A post-commit throw can no longer be mislabelled as a failed load, so the outer catch now only fires for genuine blank-canvas failures.
- **Re-arm on the paths that commit real content**, since the flag is still false after a failed hydrate: `newSchematic`, `importFromJSON` (file open / share link / cloud open), and `importCsvData`. That last one is easy to miss because it merges into the current document rather than replacing it — without it, a CSV import after a failed hydrate populates the canvas and never persists a single row.
- **Split `importFromJSON`'s post-import side-effects into two sibling `try/catch` blocks.** They shared one `try`, so a malformed `pages` shape threw past `saveCategoryOrder` + `saveToLocalStorage` and left the imported schematic unsaved until the next edit. On the recovery path — importing to get out of a failed hydrate — a reload before that edit dropped the user back onto the old unreadable blob. Both halves stay guarded, so neither can propagate and re-trigger #176.
- **The first-run demo path arms autosave even on failure**: empty storage means there's no saved copy to protect, so a new visitor's own edits should still persist.

### One known gap I deliberately left out

After a failed hydrate, the explicit save paths still don't re-arm autosave — `adoptLocalFile` (Save / Save As) and the cloud setters both call `saveToLocalStorage` under the false flag.

Arming inside `adoptLocalFile` looks like the obvious one-line fix, but it's actively unsafe: `MenuBar` calls it **before** `writeToFileHandle` resolves (`handleSave`, `handleSaveAs`) and **even when `importFromJSON` just threw** (`handleOpen`). Arming there would overwrite the recoverable blob on a failed write or a bad file — the exact failure this PR exists to prevent.

Doing it properly means arming only after a confirmed successful write, inside those handlers. That's a wider change, in flows where the user's work is already durable on disk or in the cloud, so I left it out to keep this PR focused. Happy to add it here if you'd prefer.

### Tests

New `src/__tests__/store.dataloss.test.ts`, 6 cases: the corrupt blob isn't overwritten and the failure is surfaced; each re-arm path (asserting on the persisted bytes, not just that a write happened); a post-commit side-effect throw still leaves the schematic loaded with autosave armed — which pins the ordering so a future change can't quietly move `hydrated` back below `syncRackCounters`; and an import with a malformed `pages` shape still persists.

Every case was verified to **fail against the unpatched store** before passing, so they're real regression tests rather than confirmation of current behaviour.

### Verification

`npm run lint` (0 errors), `npm test` (530 passing), `npm run routing:check` (byte-identical), `npm run build` — all green. No schema or version bump.
