### PR TITLE
fix(store): advance the print-sheet id counter for viewport-less sheets

### DIFF
--- a/src/__tests__/printSheetCounter.test.ts
+++ b/src/__tests__/printSheetCounter.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { SchematicFile } from "../types";
+
+// The store reads `localStorage` at module-creation time and the vitest env is
+// `node`, so we stub an in-memory localStorage BEFORE the dynamic import, and
+// reset modules each test so the module-level ID counters start fresh (#3 review).
+describe("print-sheet id counter sync (duplicate page id, review #3)", () => {
+  beforeEach(() => {
+    const mem = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => (mem.has(k) ? mem.get(k)! : null),
+      setItem: (k: string, v: string) => { mem.set(k, String(v)); },
+      removeItem: (k: string) => { mem.delete(k); },
+      clear: () => mem.clear(),
+      key: (i: number) => Array.from(mem.keys())[i] ?? null,
+      get length() { return mem.size; },
+    });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("advances printSheetIdCounter for a print sheet with no viewports", async () => {
+    const { useSchematicStore } = await import("../store");
+    const { CURRENT_SCHEMA_VERSION } = await import("../migrations");
+
+    // A plain print sheet (printsheet-3) with an empty viewports array — exactly
+    // what `addPrintSheetPage` creates before any rack viewport is added.
+    const file: SchematicFile = {
+      version: CURRENT_SCHEMA_VERSION,
+      name: "test",
+      nodes: [],
+      edges: [],
+      pages: [
+        {
+          id: "printsheet-3",
+          label: "Sheet 3",
+          type: "print-sheet",
+          paperId: "letter",
+          orientation: "landscape",
+          viewports: [],
+          showTitleBlock: true,
+        },
+      ],
+    };
+
+    useSchematicStore.getState().importFromJSON(file);
+
+    // The next new print sheet must NOT reuse an existing id. Before the fix the
+    // counter never advanced (the bump was nested in the empty viewport loop), so
+    // this returned "printsheet-1"; now it correctly continues past the loaded 3.
+    const newId = useSchematicStore.getState().addPrintSheetPage();
+    expect(newId).toBe("printsheet-4");
+  });
+});

--- a/src/store.ts
+++ b/src/store.ts
@@ -897,14 +897,18 @@ function syncRackCounters(pages: SchematicPage[]) {
     const pm = page.id.match(/^rackpage-(\d+)$/);
     if (pm) rackPageIdCounter = Math.max(rackPageIdCounter, Number(pm[1]));
     if (page.type === "print-sheet") {
+      // The print-sheet id counter must advance for EVERY print sheet, even one
+      // with no viewports: a new sheet is created with `viewports: []`, so nesting
+      // this bump inside the viewport loop below left plain sheets unable to
+      // advance the counter on reload — the next new sheet then reused the id.
+      const sm = page.id.match(/^printsheet-(\d+)$/);
+      if (sm) printSheetIdCounter = Math.max(printSheetIdCounter, Number(sm[1]));
       // Arrays default to [] — an older/partial page missing these would throw
       // "not iterable" here, AFTER importFromJSON already loaded the schematic,
       // surfacing to callers as a false "Invalid schematic file." (#176)
       for (const vp of page.viewports ?? []) {
         const vm = vp.id.match(/^viewport-(\d+)$/);
         if (vm) viewportIdCounter = Math.max(viewportIdCounter, Number(vm[1]));
-        const sm = page.id.match(/^printsheet-(\d+)$/);
-        if (sm) printSheetIdCounter = Math.max(printSheetIdCounter, Number(sm[1]));
       }
       continue;
     }


### PR DESCRIPTION
### The bug

`syncRackCounters` re-derives the module-level ID counters when a schematic loads. The `printsheet-(\d+)` bump was nested **inside** the `for (const vp of page.viewports ?? [])` loop:

```js
for (const vp of page.viewports ?? []) {
  const vm = vp.id.match(/^viewport-(\d+)$/);
  if (vm) viewportIdCounter = Math.max(viewportIdCounter, Number(vm[1]));
  const sm = page.id.match(/^printsheet-(\d+)$/);   // <- never runs for an empty viewports[]
  if (sm) printSheetIdCounter = Math.max(printSheetIdCounter, Number(sm[1]));
}
```

Every new print sheet is created with `viewports: []`, so a plain sheet — one the user never added a rack viewport to — never advanced the counter on reload. The next `addPrintSheetPage()` then re-minted an already-used `printsheet-N`, leaving two pages with the same id.

### The fix

Hoist the bump out of the viewport loop so it runs once per print-sheet page regardless of viewport count. The per-viewport bump stays where it belongs.

It's pure statement reordering: the counter is a monotonic `Math.max`, and the print-sheet `continue` below still keeps the rack / placement / accessory counters from touching print sheets.

### Test

`src/__tests__/printSheetCounter.test.ts` drives the real `importFromJSON()` + `addPrintSheetPage()` path with a viewport-less `printsheet-3` and asserts the next sheet is `printsheet-4`. Verified to fail against the unpatched store first, so it's a real regression test rather than a restatement of current behaviour.

### Verification

`npm run lint` (0 errors), `npm test` (525 passing), `npm run routing:check` (byte-identical), `npm run build` — all green. No schema or version bump.

While I was in here I checked the neighbouring `if (page.type === "patch-panel") continue;` for the same class of bug — it's fine, since patch-panel pages use the fixed singleton id `"patchbay-1"` and have no counter to sync.
